### PR TITLE
Make dependencies a typed struct instead of list

### DIFF
--- a/pkg/publish/github.go
+++ b/pkg/publish/github.go
@@ -40,10 +40,11 @@ func Github(manifest model.Manifest, githubOrg string) error {
 	tc := oauth2.NewClient(ctx, ts)
 	client := github.NewClient(tc)
 
-	for _, dep := range manifest.Dependencies {
+	for _, repo := range manifest.Dependencies.List() {
+		dep := manifest.Dependencies.Get(repo)
 		// Do not use dep.Org, as the source org is not necessarily the same as the publishing org
-		if err := GithubTag(client, githubOrg, dep.Repo, manifest.Version, dep.Sha); err != nil {
-			return fmt.Errorf("failed to tag repo %v: %v", dep.Repo, err)
+		if err := GithubTag(client, githubOrg, repo, manifest.Version, dep.Sha); err != nil {
+			return fmt.Errorf("failed to tag repo %v: %v", repo, err)
 		}
 	}
 

--- a/release/daily.sh
+++ b/release/daily.sh
@@ -35,14 +35,14 @@ version: ${VERSION}
 docker: docker.io/istio
 directory: ${WORK_DIR}
 dependencies:
-  - org: istio
-    repo: istio
+  istio:
     branch: master
-  - org: istio
-    repo: cni
+    git: https://github.com/istio/istio
+  cni:
     auto: deps
+    git: https://github.com/istio/cni
 outputs:
-- docker
+- archive
 EOF
 )
 


### PR DESCRIPTION
I've realized now we will need to be explicit about dependencies -- they
are always required and we treat them specially (istio/istio is the
source of auto dependencies, proxy is handled differently, etc), so it
makes more sense to specify them directly rather than a list