### PR TITLE
Validate only the input manifest

### DIFF
--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -73,9 +73,6 @@ func ReadManifest(manifestFile string) (model.Manifest, error) {
 	if err := yaml.Unmarshal(by, &manifest); err != nil {
 		return manifest, fmt.Errorf("failed to unmarshal manifest file: %v", err)
 	}
-	if err := validateManifestDependencies(manifest.Dependencies); err != nil {
-		return manifest, fmt.Errorf("invalid manifest: %v", err)
-	}
 	return manifest, nil
 }
 

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -54,5 +54,5 @@ export PATH=${GOPATH}/bin:${PATH}
 go run main.go build --manifest <(echo "${MANIFEST}")
 
 if [[ -z "${DRY_RUN:-}" ]]; then
-  go run main.go publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --dockerhub "${DOCKER_HUB}" --dockertags "${TAG}"
+  go run main.go publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}"
 fi

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -28,7 +28,7 @@ else
 fi
 
 DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
-GCS_BUCKET=${GCS_BUCKET:-istio-prerelease/test}
+GCS_BUCKET=${GCS_BUCKET:-istio-build/test}
 VERSION="release-builder-$(git rev-parse HEAD)"
 
 WORK_DIR="$(mktemp -d)/build"


### PR DESCRIPTION
The standard manifest is not a user input, so no need to validate it.
This is triggered by the fact that the validation is not actually
correct for the standard manifest, as it has no requirement for the git
source specified.