### PR TITLE
Fix version and tag replacement

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -34,9 +34,9 @@ import (
 var (
 	// Currently tags are set as `release-1.x-latest-daily` or `latest` or `1.x-dev`
 	tagRegexes = []*regexp.Regexp{
-		regexp.MustCompile(`tag: .*-latest-daily$`),
-		regexp.MustCompile(`tag: latest$`),
-		regexp.MustCompile(`tag: 1\..-dev$`),
+		regexp.MustCompile(`tag: .*-latest-daily`),
+		regexp.MustCompile(`tag: latest`),
+		regexp.MustCompile(`tag: 1\..-dev`),
 	}
 
 	// Currently tags are set as `gcr.io/istio-testing` or `gcr.io/istio-release`

--- a/pkg/util/command.go
+++ b/pkg/util/command.go
@@ -29,7 +29,7 @@ import (
 func RunMake(manifest model.Manifest, repo string, env []string, c ...string) error {
 	cmd := VerboseCommand("make", c...)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOPATH="+manifest.WorkDir(), "TAG="+manifest.Version, "VERSION="+manifest.Version)
+	cmd.Env = append(cmd.Env, "GOPATH="+manifest.WorkDir(), "TAG="+manifest.Version, "VERSION="+manifest.Version, "ISTIO_VERSION="+manifest.Version)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout

--- a/pkg/util/command.go
+++ b/pkg/util/command.go
@@ -29,7 +29,7 @@ import (
 func RunMake(manifest model.Manifest, repo string, env []string, c ...string) error {
 	cmd := VerboseCommand("make", c...)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "GOPATH="+manifest.WorkDir(), "TAG="+manifest.Version, "ISTIO_VERSION="+manifest.Version)
+	cmd.Env = append(cmd.Env, "GOPATH="+manifest.WorkDir(), "TAG="+manifest.Version, "VERSION="+manifest.Version)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This got merged because the tests were merged before istio/istio
switched tags, and the tests don't run on istio/istio