### PR TITLE
Include transitive dependencies

### DIFF
--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -56,11 +56,12 @@ func InputManifestToManifest(in model.InputManifest) (model.Manifest, error) {
 		outputs[model.Archive] = struct{}{}
 	}
 	return model.Manifest{
-		Dependencies: in.Dependencies,
-		Version:      in.Version,
-		Docker:       in.Docker,
-		Directory:    wd,
-		BuildOutputs: outputs,
+		TopDependencies: in.Dependencies,
+		AllDependencies: make(map[string]string),
+		Version:         in.Version,
+		Docker:          in.Docker,
+		Directory:       wd,
+		BuildOutputs:    outputs,
 	}, nil
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -114,8 +114,10 @@ type InputManifest struct {
 
 // Manifest defines what is in a release
 type Manifest struct {
-	// Dependencies declares all git repositories used to build this release
-	Dependencies IstioDependencies `json:"dependencies"`
+	// TopDependencies declares all git repositories used to build this release
+	TopDependencies IstioDependencies `json:"-"`
+	// AllDependencies includes all Istio dependencies, as well as transitive dependencies
+	AllDependencies map[string]string `json:"dependencies"`
 	// Version specifies what version of Istio this release is
 	Version string `json:"version"`
 	// Docker specifies the docker hub to use in the helm charts.

--- a/pkg/publish/github.go
+++ b/pkg/publish/github.go
@@ -45,10 +45,9 @@ func Github(manifest model.Manifest, githubOrg string) error {
 	tc := oauth2.NewClient(ctx, ts)
 	client := github.NewClient(tc)
 
-	for _, repo := range manifest.Dependencies.List() {
-		dep := manifest.Dependencies.Get(repo)
+	for repo, sha := range manifest.AllDependencies {
 		// Do not use dep.Org, as the source org is not necessarily the same as the publishing org
-		if err := GithubTag(client, githubOrg, repo, manifest.Version, dep.Sha); err != nil {
+		if err := GithubTag(client, githubOrg, repo, manifest.Version, sha); err != nil {
 			return fmt.Errorf("failed to tag repo %v: %v", repo, err)
 		}
 	}

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -185,10 +185,10 @@ func TestHelmVersions(t *testing.T) {
 }
 
 func TestManifest(t *testing.T) {
-	for _, repo := range manifest.Dependencies.List() {
+	for _, repo := range []string{"api", "cni", "gogo-genproto", "istio", "operator", "pkg", "proxy"} {
 		t.Run(repo, func(t *testing.T) {
-			d := manifest.Dependencies.Get(repo)
-			if d.Sha == "" {
+			d, f := manifest.AllDependencies[repo]
+			if !f || d == "" {
 				t.Fatalf("Got empty SHA")
 			}
 		})


### PR DESCRIPTION
This change fetches all istio dependencies from istio.deps and go.mod.
This allows recording these in the manifest.yaml file, as well as
tagging them as part of the github release process.