### PR TITLE
Add publish and build trigger warnings

### DIFF
--- a/release/build-warning.sh
+++ b/release/build-warning.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+
+set -eu
+
+PRERELEASE_DOCKER_HUB=${PRERELEASE_DOCKER_HUB:-gcr.io/istio-prerelease-testing}
+GCS_BUCKET=${GCS_BUCKET:-istio-prerelease/prerelease}
+
+VERSION="$(cat "${WD}/trigger-build")"
+
+cat <<EOF
+WARNING
+If you are seeing this test, you have modified the trigger-build file.
+
+This will trigger a official build of Istio once merged.
+
+If this is unexpected, do not merge this PR.
+
+If this is expected, this message can be ignored.
+
+Build information
+=================
+Version: ${VERSION}
+Staging GCS Bucket: ${GCS_BUCKET}
+Staging Docker Hub: ${PRERELEASE_DOCKER_HUB}
+EOF
+
+exit 1

--- a/release/publish-warning.sh
+++ b/release/publish-warning.sh
@@ -45,7 +45,7 @@ Docker Hub: ${DOCKER_HUB}
 Github Org: ${GITHUB_ORG}
 Source: ${SOURCE_GCS_BUCKET}/${VERSION}
 Contents:
-$(gsutil ls -r gs://${SOURCE_GCS_BUCKET}/${VERSION})
+$(gsutil ls -r "gs://${SOURCE_GCS_BUCKET}/${VERSION}")
 EOF
 
 exit 2

--- a/release/publish-warning.sh
+++ b/release/publish-warning.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+
+set -eu
+
+SOURCE_GCS_BUCKET=${SOURCE_GCS_BUCKET:-istio-prerelease/prerelease}
+GCS_BUCKET=${GCS_BUCKET:-istio-release/releases}
+DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
+GITHUB_ORG=${GITHUB_ORG:-istio}
+
+VERSION="$(cat "${WD}/trigger-publish")"
+
+cat <<EOF
+WARNING
+If you are seeing this test, you have modified the trigger-publish file.
+
+This will publish an official build of Istio once merged.
+
+If this is unexpected, do not merge this PR.
+
+If this is expected, this message can be ignored.
+
+Build information
+=================
+Version: ${VERSION}
+
+GCS Bucket: ${GCS_BUCKET}
+Docker Hub: ${DOCKER_HUB}
+Github Org: ${GITHUB_ORG}
+Source: ${SOURCE_GCS_BUCKET}/${VERSION}
+Contents:
+$(gsutil ls -r gs://${SOURCE_GCS_BUCKET}/${VERSION})
+EOF
+
+exit 2


### PR DESCRIPTION
The plan is to have a presubmit test and a postsubmit test with
run_if_changed for the trigger files. In presubmit, we will run these
scripts, which fail every time with a warning. The test will be optional
so it will not block the change, but will be a big warning that this is
going to trigger a build. Once merged, the run_if_changed on the
postsubmit will actually trigger the build/publish.

This may be a bit paranoid, but I really don't want to accidentally publish a build