### PR TITLE
Pass full SHA to manifest for transitive dependency

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -84,7 +84,7 @@ func writeLicense(manifest model.Manifest) error {
 		return err
 	}
 
-	cmd := util.VerboseCommand("license-lint", "--config", "common/config/license-lint.yml", "--report")
+	cmd := util.VerboseCommand("license-lint", "--config", "common/config/license-lint.yml", "--dump")
 	cmd.Dir = manifest.RepoDir("istio")
 	o, err := os.Create(path.Join(manifest.OutDir(), "LICENSES"))
 	if err != nil {

--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -56,12 +56,11 @@ func InputManifestToManifest(in model.InputManifest) (model.Manifest, error) {
 		outputs[model.Archive] = struct{}{}
 	}
 	return model.Manifest{
-		TopDependencies: in.Dependencies,
-		AllDependencies: make(map[string]string),
-		Version:         in.Version,
-		Docker:          in.Docker,
-		Directory:       wd,
-		BuildOutputs:    outputs,
+		Dependencies: in.Dependencies,
+		Version:      in.Version,
+		Docker:       in.Docker,
+		Directory:    wd,
+		BuildOutputs: outputs,
 	}, nil
 }
 
@@ -78,8 +77,7 @@ func ReadManifest(manifestFile string) (model.Manifest, error) {
 }
 
 func validateManifestDependencies(dependencies model.IstioDependencies) error {
-	for _, repo := range dependencies.List() {
-		dep := dependencies.Get(repo)
+	for repo, dep := range dependencies.Get() {
 		if dep == nil {
 			return fmt.Errorf("missing dependency: %v", repo)
 		}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -63,7 +63,7 @@ type IstioDependencies struct {
 	Istio    Dependency `json:"istio"`
 	Cni      Dependency `json:"cni"`
 	Operator Dependency `json:"operator"`
-	Api      Dependency `json:"api"`
+	Api      Dependency `json:"api"` //nolint: golint
 	Proxy    Dependency `json:"proxy"`
 	Pkg      Dependency `json:"pkg"`
 	Client   Dependency `json:"client-go"`

--- a/pkg/publish/github.go
+++ b/pkg/publish/github.go
@@ -45,9 +45,9 @@ func Github(manifest model.Manifest, githubOrg string, githubToken string) error
 	tc := oauth2.NewClient(ctx, ts)
 	client := github.NewClient(tc)
 
-	for repo, sha := range manifest.AllDependencies {
+	for repo, dep := range manifest.Dependencies.Get() {
 		// Do not use dep.Org, as the source org is not necessarily the same as the publishing org
-		if err := GithubTag(client, githubOrg, repo, manifest.Version, sha); err != nil {
+		if err := GithubTag(client, githubOrg, repo, manifest.Version, dep.Sha); err != nil {
 			return fmt.Errorf("failed to tag repo %v: %v", repo, err)
 		}
 	}

--- a/release/build.sh
+++ b/release/build.sh
@@ -52,6 +52,18 @@ dependencies:
   operator:
     git: https://github.com/istio/operator
     auto: modules
+  api:
+    git: https://github.com/istio/api
+    auto: modules
+  proxy:
+    git: https://github.com/istio/proxy
+    auto: deps
+  pkg:
+    git: https://github.com/istio/pkg
+    auto: modules
+  client-go:
+    git: https://github.com/istio/client-go
+    branch: release-1.4
 EOF
 )
 

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -48,6 +48,18 @@ dependencies:
   operator:
     git: https://github.com/istio/operator
     auto: modules
+  api:
+    git: https://github.com/istio/api
+    auto: modules
+  proxy:
+    git: https://github.com/istio/proxy
+    auto: deps
+  pkg:
+    git: https://github.com/istio/pkg
+    auto: modules
+  client-go:
+    git: https://github.com/istio/client-go
+    branch: master
 EOF
 )
 

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -185,7 +185,7 @@ func TestHelmVersions(t *testing.T) {
 }
 
 func TestManifest(t *testing.T) {
-	for _, repo := range []string{"api", "cni", "gogo-genproto", "istio", "operator", "pkg", "proxy"} {
+	for _, repo := range []string{"api", "cni", "client-go", "istio", "operator", "pkg", "proxy"} {
 		t.Run(repo, func(t *testing.T) {
 			d, f := manifest.Dependencies.Get()[repo]
 			if !f || d.Sha == "" {

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -187,8 +187,8 @@ func TestHelmVersions(t *testing.T) {
 func TestManifest(t *testing.T) {
 	for _, repo := range []string{"api", "cni", "gogo-genproto", "istio", "operator", "pkg", "proxy"} {
 		t.Run(repo, func(t *testing.T) {
-			d, f := manifest.AllDependencies[repo]
-			if !f || d == "" {
+			d, f := manifest.Dependencies.Get()[repo]
+			if !f || d.Sha == "" {
 				t.Fatalf("Got empty SHA")
 			}
 		})


### PR DESCRIPTION
Previously, we had two types of dependency: explicitly listed in the
manifest, and implicitly derived from istio.deps and go.mod. The
implicit ones were just used for tagging to git basically.

This model turned out to not work well, as go.mod only has the short
SHA, but we need the full SHA to do a publish to Github. In order to get
the full SHA, we need to clone the source and do a lookup. In order to
clone the source, we need to know what the source is... and at this
point we might as well explicitly list it in the manifest.

This change removes the concept of "imlicit dependency" and makes
everything explicit. This cleans up quite a few things, but the end
result should be just that SHAs are the full length, allowing github
publish to properly work.