### PR TITLE
Support license folder

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -84,7 +84,7 @@ func writeLicense(manifest model.Manifest) error {
 		src := filepath.Join(manifest.RepoDir(repo), "licenses")
 		// Just skip these, we can fail in the validation tests afterwards for repos we expect license for
 		if _, err := os.Stat(src); os.IsNotExist(err) {
-			log.Warnf("skipping license for %v")
+			log.Warnf("skipping license for %v", repo)
 			continue
 		}
 		if err := util.CopyDir(src, filepath.Join(manifest.OutDir(), "licenses", repo)); err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -19,8 +19,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/ghodss/yaml"
+
+	"istio.io/pkg/log"
 
 	"istio.io/release-builder/pkg/model"
 	"istio.io/release-builder/pkg/util"
@@ -75,25 +78,18 @@ func Build(manifest model.Manifest) error {
 	return nil
 }
 
-// writeLicense will output a LICENSES file with a complete list of licenses from all dependencies.
+// writeLicense copies the complete list of licenses for all dependant repos
 func writeLicense(manifest model.Manifest) error {
-	// License tool requires all dependencies to be downloaded
-	mcmd := util.VerboseCommand("go", "mod", "download")
-	mcmd.Dir = manifest.RepoDir("istio")
-	if err := mcmd.Run(); err != nil {
-		return err
-	}
-
-	cmd := util.VerboseCommand("license-lint", "--config", "common/config/license-lint.yml", "--dump")
-	cmd.Dir = manifest.RepoDir("istio")
-	o, err := os.Create(path.Join(manifest.OutDir(), "LICENSES"))
-	if err != nil {
-		return err
-	}
-	cmd.Stdout = o
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("unable to generate license report for the istio repo: %v", err)
+	for repo := range manifest.Dependencies.Get() {
+		src := filepath.Join(manifest.RepoDir(repo), "licenses")
+		// Just skip these, we can fail in the validation tests afterwards for repos we expect license for
+		if _, err := os.Stat(src); os.IsNotExist(err) {
+			log.Warnf("skipping license for %v")
+			continue
+		}
+		if err := util.CopyDir(src, filepath.Join(manifest.OutDir(), "licenses", repo)); err != nil {
+			return fmt.Errorf("failed to copy license for %v: %v", repo, err)
+		}
 	}
 	return nil
 }

--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg/model"
 )
 
@@ -80,7 +81,10 @@ func ReadManifest(manifestFile string) (model.Manifest, error) {
 func validateManifestDependencies(dependencies model.IstioDependencies) error {
 	for repo, dep := range dependencies.Get() {
 		if dep == nil {
-			return fmt.Errorf("missing dependency: %v", repo)
+			// Missing a dependency is not always a failure; many are optional dependencies just for
+			// tagging.
+			log.Warnf("missing dependency: %v", repo)
+			continue
 		}
 		if dep.Branch != "" || dep.Sha != "" || dep.Auto != "" {
 			if dep.Git == "" {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -60,24 +60,30 @@ func (d Dependency) Ref() string {
 
 // Dependencies for the build
 type IstioDependencies struct {
-	Istio    Dependency `json:"istio"`
-	Cni      Dependency `json:"cni"`
-	Operator Dependency `json:"operator"`
-	Api      Dependency `json:"api"` //nolint: golint, stylechecker
-	Proxy    Dependency `json:"proxy"`
-	Pkg      Dependency `json:"pkg"`
-	Client   Dependency `json:"client-go"`
+	Istio        *Dependency `json:"istio"`
+	Cni          *Dependency `json:"cni"`
+	Operator     *Dependency `json:"operator"`
+	Api          *Dependency `json:"api"` //nolint: golint, stylechecker
+	Proxy        *Dependency `json:"proxy"`
+	Pkg          *Dependency `json:"pkg"`
+	ClientGo     *Dependency `json:"client-go"`
+	GogoGenproto *Dependency `json:"gogo-genproto"`
+	TestInfra    *Dependency `json:"test-infra"`
+	Tools        *Dependency `json:"tools"`
 }
 
 func (i *IstioDependencies) Get() map[string]*Dependency {
 	return map[string]*Dependency{
-		"istio":     &i.Istio,
-		"cni":       &i.Cni,
-		"operator":  &i.Operator,
-		"api":       &i.Api,
-		"proxy":     &i.Proxy,
-		"pkg":       &i.Pkg,
-		"client-go": &i.Client,
+		"istio":         i.Istio,
+		"cni":           i.Cni,
+		"operator":      i.Operator,
+		"api":           i.Api,
+		"proxy":         i.Proxy,
+		"pkg":           i.Pkg,
+		"client-go":     i.ClientGo,
+		"gogo-genproto": i.GogoGenproto,
+		"test-infra":    i.TestInfra,
+		"tools":         i.Tools,
 	}
 }
 
@@ -85,6 +91,9 @@ func (i *IstioDependencies) Get() map[string]*Dependency {
 func (i IstioDependencies) MarshalJSON() ([]byte, error) {
 	deps := make(map[string]Dependency)
 	for repo, dep := range i.Get() {
+		if dep == nil {
+			continue
+		}
 		deps[repo] = Dependency{Sha: dep.Sha}
 	}
 	return json.Marshal(deps)

--- a/pkg/publish/github.go
+++ b/pkg/publish/github.go
@@ -46,6 +46,10 @@ func Github(manifest model.Manifest, githubOrg string, githubToken string) error
 	client := github.NewClient(tc)
 
 	for repo, dep := range manifest.Dependencies.Get() {
+		if dep == nil {
+			log.Warnf("skipping missing dependency %v", repo)
+			continue
+		}
 		// Do not use dep.Org, as the source org is not necessarily the same as the publishing org
 		if err := GithubTag(client, githubOrg, repo, manifest.Version, dep.Sha); err != nil {
 			return fmt.Errorf("failed to tag repo %v: %v", repo, err)

--- a/release/build.sh
+++ b/release/build.sh
@@ -64,6 +64,15 @@ dependencies:
   client-go:
     git: https://github.com/istio/client-go
     branch: release-1.4
+  gogo-genproto:
+    git: https://github.com/istio/gogo-genproto
+    branch: release-1.4
+  test-infra:
+    git: https://github.com/istio/test-infra
+    branch: release-1.4
+  tools:
+    git: https://github.com/istio/tools
+    branch: release-1.4
 EOF
 )
 

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -60,6 +60,15 @@ dependencies:
   client-go:
     git: https://github.com/istio/client-go
     branch: master
+  gogo-genproto:
+    git: https://github.com/istio/gogo-genproto
+    branch: master
+  test-infra:
+    git: https://github.com/istio/test-infra
+    branch: master
+  tools:
+    git: https://github.com/istio/tools
+    branch: master
 EOF
 )
 

--- a/test/validation_test.go
+++ b/test/validation_test.go
@@ -211,16 +211,24 @@ func TestDemo(t *testing.T) {
 }
 
 func TestLicenses(t *testing.T) {
-	l, err := ioutil.ReadFile(filepath.Join(*release, "LICENSES"))
-	license := string(l)
+	l, err := ioutil.ReadDir(filepath.Join(*release, "licenses"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	// We don't have a great way to validate the license file was generated properly
-	// If it has an Apache and MIT license, we can have at least some level of confidence
-	for _, l := range []string{"Apache License", "MIT License"} {
-		if !strings.Contains(license, l) {
-			t.Fatalf("LICENSE may be invalid. Expected %v but got: %v", l, license)
-		}
+	// Expect to find license folders for these repos
+	expect := map[string]struct{}{
+		"istio":         {},
+		"gogo-genproto": {},
+		"client-go":     {},
+		"tools":         {},
+		"test-infra":    {},
+	}
+
+	for _, repo := range l {
+		delete(expect, repo.Name())
+	}
+
+	if len(expect) > 0 {
+		t.Fatalf("Failed to find licenses for: %v", expect)
 	}
 }


### PR DESCRIPTION
Currently, we pile all licenses into one file. Now, each repo has the
license vendored in. We should just copy this file.

In order to support this change, we need to list out more dependencies.
It doesn't make sense to require builds to have a test-infra, tools,
etc, which are optional dependencies. For example, on private builds,
this would be really weird to require. Because of this, this change also
allows dependencies to be optional, with ample warning if they are
missing.

Note: for now the license test is pretty lenient, because we need to
update all the repos still.