### PR TITLE
Update version in requirements.yaml

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -115,7 +115,7 @@ func sanitizeChart(manifest model.Manifest, s string) error {
 	cv := chart["appVersion"].(string)
 	if err := filepath.Walk(s, func(p string, info os.FileInfo, err error) error {
 		fname := path.Base(p)
-		if fname == "Chart.yaml" || fname == "values.yaml" || fname == "values_gke.yaml" {
+		if fname == "Chart.yaml" || fname == "values.yaml" || fname == "values_gke.yaml" || fname == "requirements.yaml" {
 			read, err := ioutil.ReadFile(p)
 			if err != nil {
 				return err


### PR DESCRIPTION
In the release archive for v1.4.0, the chart versions in `requirements.yaml` file are `1.1.0`. They should be `1.4.0`. This PR attempts to fix this. 

Ref https://github.com/istio/istio/issues/19058

