### PR TITLE
Prevent nil pointer in TestManifest

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -283,7 +283,10 @@ func TestOperator(r ReleaseInfo) error {
 func TestManifest(r ReleaseInfo) error {
 	for _, repo := range []string{"api", "cni", "client-go", "istio", "operator", "pkg", "proxy"} {
 		d, f := r.manifest.Dependencies.Get()[repo]
-		if !f || d.Sha == "" {
+		if !f || d == nil {
+			continue
+		}
+		if d.Sha == "" {
 			return fmt.Errorf("got empty SHA for %v", repo)
 		}
 	}


### PR DESCRIPTION
When only the required dependencies are supplied in the **manifest** (i.e. istio, cni, operator, proxy) the *validation* fails.

> This may not be the correct approach. Alternatively, a flag (i.e. `--minimal`) or just including *all* the dependencies may be better.

> Also, I have yet to verify if other tests need an update as well, but I surmise at least some others, like `TestLicenses`, will fail as well.