### PR TITLE
Remove archiving istio-iptables.sh

### DIFF
--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -49,7 +49,6 @@ func Archive(manifest model.Manifest) error {
 
 			// Setup tools. The tools/ folder contains a bunch of extra junk, so just select exactly what we want
 			"tools/convert_RbacConfig_to_ClusterRbacConfig.sh",
-			"tools/packaging/common/istio-iptables.sh",
 			"tools/dump_kubernetes.sh",
 		}
 		for _, file := range directCopies {


### PR DESCRIPTION
istio-iptables.sh is replaced by golang impl.
We plan to delete istio-iptables.sh (https://github.com/istio/istio/pull/19273)