### PR TITLE
fix not set GOPATH

### DIFF
--- a/test/publish.sh
+++ b/test/publish.sh
@@ -74,7 +74,9 @@ EOF
 )
 
 # "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
+if [[ -z ${GOPATH} ]]; then
+  export PATH=${GOPATH}/bin:${PATH}
+fi
 
 go run main.go build --manifest <(echo "${MANIFEST}")
 


### PR DESCRIPTION
if there is not set GOPATH
publish.sh will report error:
./test/publish.sh: line 77: GOPATH: unbound variable

from go 1.12, there is no need to set GOPATH for go.