### PR TITLE
Changes required to do a release build on a Mac

### DIFF
--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -103,7 +103,7 @@ func Archive(manifest model.Manifest) error {
 			istioctlBinary += ".exe"
 			istioctlDest += ".exe"
 		}
-		if err := util.CopyFile(path.Join(manifest.RepoOutDir("istio"), istioctlBinary), path.Join(out, "bin", istioctlDest)); err != nil {
+		if err := util.CopyFile(path.Join(os.Getenv("TARGET_OUT"), "release", istioctlBinary), path.Join(out, "bin", istioctlDest)); err != nil {
 			return err
 		}
 		if err := os.Chmod(path.Join(out, "bin", istioctlDest), 0755); err != nil {
@@ -113,7 +113,7 @@ func Archive(manifest model.Manifest) error {
 		// Copy the istioctl completions files to the tools directory
 		completionFiles := []string{"istioctl.bash", "_istioctl"}
 		for _, file := range completionFiles {
-			if err := util.CopyFile(path.Join(manifest.RepoOutDir("istio"), file), path.Join(out, "tools", file)); err != nil {
+			if err := util.CopyFile(path.Join(os.Getenv("TARGET_OUT"), "release", file), path.Join(out, "tools", file)); err != nil {
 				return err
 			}
 		}

--- a/pkg/build/debian.go
+++ b/pkg/build/debian.go
@@ -16,6 +16,7 @@ package build
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	"istio.io/release-builder/pkg/model"
@@ -24,10 +25,13 @@ import (
 
 // Debian produces a debian package just for the sidecar
 func Debian(manifest model.Manifest) error {
+	// Create the artifacts in the manifest directory structure
+	// env := []string{"TARGET_OUT_LINUX=" + manifest.RepoDir("istio"), "TARGET_OUT=" + manifest.RepoDir("istio")}
+
 	if err := util.RunMake(manifest, "istio", nil, "sidecar.deb"); err != nil {
 		return fmt.Errorf("failed to build sidecar.deb: %v", err)
 	}
-	if err := util.CopyFile(path.Join(manifest.RepoOutDir("istio"), "istio-sidecar.deb"), path.Join(manifest.OutDir(), "deb", "istio-sidecar.deb")); err != nil {
+	if err := util.CopyFile(path.Join(os.Getenv("TARGET_OUT_LINUX"), "release", "istio-sidecar.deb"), path.Join(manifest.OutDir(), "deb", "istio-sidecar.deb")); err != nil {
 		return fmt.Errorf("failed to package istio-sidecar.deb: %v", err)
 	}
 	if err := util.CreateSha(path.Join(manifest.OutDir(), "deb", "istio-sidecar.deb")); err != nil {

--- a/pkg/build/docker.go
+++ b/pkg/build/docker.go
@@ -45,8 +45,10 @@ func Docker(manifest model.Manifest) error {
 		}
 	}
 	// Others output to GoOut, so copy those as well
-	if err := util.CopyFilesToDir(path.Join(manifest.GoOutDir(), "docker"), path.Join(manifest.OutDir(), "docker")); err != nil {
-		return fmt.Errorf("failed to package docker images: %v", err)
+	if util.FileExists(path.Join(manifest.GoOutDir(), "docker")) {
+		if err := util.CopyFilesToDir(path.Join(manifest.GoOutDir(), "docker"), path.Join(manifest.OutDir(), "docker")); err != nil {
+			return fmt.Errorf("failed to package docker images: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Changes I needed to do a release build on my Mac.

I'm not sure necessarily why some of the `make` output paths seem to be different, but this is what I needed to do to get past the `go run main.go build --manifest <manifest>`. 

I still need to run the _validate_