### PR TITLE
addition of ARMv7 and ARM64 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ directory in your current working directory. The `artifacts` directory will cont
 
 | Syntax | Description |
 | --- | ----------- |
-| istio-{version}-{linux/osx/win}.tar.gz | _Release archive that users will download_ |
-| istioctl-{version}-{linux/osx/win}.tar.gz | |
+| istio-{version}-{linux-<arch>/osx/win}.tar.gz | _Release archive that users will download_ |
+| istioctl-{version}-{linux-<arch>/osx/win}.tar.gz | |
 | manifest.yaml | _Defines what dependencies were a part of the build_ |
 | sources.tar.gz | _Bundle of all sources used in the build_|
 | "charts" subdirectory | _Operator release charts_ |

--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -32,7 +32,7 @@ func Archive(manifest model.Manifest) error {
 	}
 
 	// We build archives for each arch. These contain the same thing except arch specific istioctl
-	for _, arch := range []string{"linux", "osx", "win"} {
+	for _, arch := range []string{"linux-amd64", "linux-armv7", "linux-arm64", "osx", "win"} {
 		out := path.Join(manifest.Directory, "work", "archive", arch, fmt.Sprintf("istio-%s", manifest.Version))
 		if err := os.MkdirAll(out, 0750); err != nil {
 			return err

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -46,7 +46,7 @@ func NewReleaseInfo(release string) ReleaseInfo {
 		panic(err)
 	}
 
-	if err := exec.Command("tar", "xvf", filepath.Join(release, fmt.Sprintf("istio-%s-linux.tar.gz", manifest.Version)), "-C", tmpDir).Run(); err != nil {
+	if err := exec.Command("tar", "xvf", filepath.Join(release, fmt.Sprintf("istio-%s-linux-amd64.tar.gz", manifest.Version)), "-C", tmpDir).Run(); err != nil {
 		log.Warnf("failed to unpackage release archive")
 	}
 	return ReleaseInfo{
@@ -113,7 +113,7 @@ func TestIstioctlArchive(r ReleaseInfo) error {
 
 func TestIstioctlStandalone(r ReleaseInfo) error {
 	// Check istioctl from stand-alone archive
-	istioctlArchivePath := filepath.Join(r.release, fmt.Sprintf("istioctl-%s-linux.tar.gz", r.manifest.Version))
+	istioctlArchivePath := filepath.Join(r.release, fmt.Sprintf("istioctl-%s-linux-amd64.tar.gz", r.manifest.Version))
 	if err := exec.Command("tar", "xvf", istioctlArchivePath, "-C", r.tmpDir).Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Removes:
- istio-linux

Adds:
- istio-linux-amd64 (replaces istio-linux)
- istio-linux-armv7
- istio-linust-arm64

Follow-up:
Remove istio-linux from istio/istio

Depends-On: https://github.com/istio/istio/pull/22381

