### PR TITLE
Fix the logic to identify SHA from a git tag

### DIFF
--- a/pkg/source.go
+++ b/pkg/source.go
@@ -108,7 +108,7 @@ func TagRepo(manifest model.Manifest, repo string) error {
 // GetSha returns the SHA for a given reference, or error if sha is not found
 func GetSha(repo string, ref string) (string, error) {
 	buf := bytes.Buffer{}
-	cmd := exec.Command("git", "rev-parse", ref)
+	cmd := exec.Command("git", "rev-list", "-n", "1", ref)
 	cmd.Stdout = &buf
 	cmd.Dir = repo
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
`git rev-parse <tag>` returns only the SHA of the tag itself and not the corresponding commit.