### PR TITLE
Update manifest chart and script paths

### DIFF
--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -60,19 +60,19 @@ func Archive(manifest model.Manifest) error {
 			return err
 		}
 
-		cmd := util.VerboseCommand("./operator/scripts/create_release_charts.sh", "-o", path.Join(out, "install/kubernetes/operator"))
+		cmd := util.VerboseCommand("./operator/scripts/create_release_charts.sh", "-o", path.Join(out, "manifests"))
 		cmd.Dir = manifest.RepoDir("istio")
 		cmd.Env = util.StandardEnv(manifest)
 		if err := cmd.Run(); err != nil {
 			return err
 		}
-		if err := sanitizeTemplate(manifest, path.Join(out, "install/kubernetes/operator/profiles/default.yaml")); err != nil {
+		if err := sanitizeTemplate(manifest, path.Join(out, "manifests/profiles/default.yaml")); err != nil {
 			return fmt.Errorf("failed to sanitize operator charts")
 		}
-		if err := util.CopyDir(path.Join(manifest.RepoDir("istio"), "operator", "deploy"), path.Join(out, "install/kubernetes/operator/deploy")); err != nil {
+		if err := util.CopyDir(path.Join(manifest.RepoDir("istio"), "operator", "deploy"), path.Join(out, "manifests/deploy")); err != nil {
 			return err
 		}
-		if err := sanitizeTemplate(manifest, path.Join(out, "install/kubernetes/operator/deploy/operator.yaml")); err != nil {
+		if err := sanitizeTemplate(manifest, path.Join(out, "manifests/deploy/operator.yaml")); err != nil {
 			return fmt.Errorf("failed to sanitize operator manifest")
 		}
 		if err := util.CopyDir(path.Join(manifest.RepoDir("istio"), "operator", "samples"), path.Join(out, "samples/operator")); err != nil {

--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -60,7 +60,7 @@ func Archive(manifest model.Manifest) error {
 			return err
 		}
 
-		cmd := util.VerboseCommand("./operator/release/create_release_charts.sh", "-o", path.Join(out, "install/kubernetes/operator"))
+		cmd := util.VerboseCommand("./operator/scripts/create_release_charts.sh", "-o", path.Join(out, "install/kubernetes/operator"))
 		cmd.Dir = manifest.RepoDir("istio")
 		cmd.Env = util.StandardEnv(manifest)
 		if err := cmd.Run(); err != nil {

--- a/pkg/build/grafana.go
+++ b/pkg/build/grafana.go
@@ -28,7 +28,7 @@ import (
 // Grafana packages Istio dashboards in a form that is ready to be published to grafana.com
 func Grafana(manifest model.Manifest) error {
 	if err := util.CopyDir(
-		path.Join(manifest.RepoDir("istio"), "manifests/istio-telemetry/grafana/dashboards"),
+		path.Join(manifest.RepoDir("istio"), "manifests/charts/istio-telemetry/grafana/dashboards"),
 		path.Join(manifest.WorkDir(), "grafana"),
 	); err != nil {
 		return err

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -253,7 +253,7 @@ func TestProxyVersion(r ReleaseInfo) error {
 
 func TestHelmVersionsOperator(r ReleaseInfo) error {
 	operatorChecks := []string{
-		"install/kubernetes/operator/profiles/default.yaml",
+		"manifests/profiles/default.yaml",
 	}
 	for _, f := range operatorChecks {
 		values, err := getValues(filepath.Join(r.archive, f))
@@ -280,7 +280,7 @@ func TestHelmVersionsOperator(r ReleaseInfo) error {
 
 func TestOperator(r ReleaseInfo) error {
 	operatorChecks := []string{
-		"install/kubernetes/operator/deploy/operator.yaml",
+		"manifests/deploy/operator.yaml",
 	}
 	for _, f := range operatorChecks {
 		expected := fmt.Sprintf("%s/operator:%s", r.manifest.Docker, r.manifest.Version)


### PR DESCRIPTION
Manifest charts path is changing in istio/istio from manifests/ to manifests/charts.
create_release_charts.sh is also moving from operator/release to operator/scripts.