### PR TITLE
remove convert_RbacConfig_to_ClusterRbacConfig.sh from the archive

### DIFF
--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -46,7 +46,6 @@ func Archive(manifest model.Manifest) error {
 			// Setup tools. The tools/ folder contains a bunch of extra junk, so just select exactly what we want
 			"tools/certs/Makefile",
 			"tools/certs/README.md",
-			"tools/convert_RbacConfig_to_ClusterRbacConfig.sh",
 			"tools/dump_kubernetes.sh",
 		}
 		for _, file := range directCopies {


### PR DESCRIPTION
This was used to convert the RbacConfig to ClusterRbacConfig. It is not needed since the whole RBAC policy has been deleted.