### PR TITLE
Fix dirty state

### DIFF
--- a/pkg/build/docker.go
+++ b/pkg/build/docker.go
@@ -33,9 +33,9 @@ func Docker(manifest model.Manifest) error {
 		env = append(env, "ISTIO_ENVOY_BASE_URL="+manifest.ProxyOverride)
 	}
 
-	// Istio operator requires compiled-in charts to be generated before the image is built.
-	if err := util.RunMake(manifest, "istio", env, "gen-charts"); err != nil {
-		return fmt.Errorf("failed to make istio gen-charts: %v", err)
+	// Make sure operator's compiled-in charts are up to date before the image is built.
+	if err := util.RunMake(manifest, "istio", env, "gen-charts", "check-clean-repo"); err != nil {
+		return fmt.Errorf("failed to verify charts are up to date. Run `make gen-charts` in istio/istio and commit the results before making a release: %v", err)
 	}
 	if err := util.RunMake(manifest, "istio", env, "docker.save"); err != nil {
 		return fmt.Errorf("failed to create %v docker archives: %v", "istio", err)

--- a/pkg/source.go
+++ b/pkg/source.go
@@ -82,13 +82,13 @@ func cloneRepo(manifest model.Manifest, repo string, dependency *model.Dependenc
 // * work/ initially contains all the sources, but may be modified during the build
 // * out/ contains all final artifacts
 func SetupWorkDir(dir string) error {
-	if err := os.Mkdir(path.Join(dir, "sources"), 0750); err != nil {
+	if err := os.MkdirAll(path.Join(dir, "sources"), 0750); err != nil {
 		return fmt.Errorf("failed to set up working directory: %v", err)
 	}
-	if err := os.Mkdir(path.Join(dir, "work"), 0750); err != nil {
+	if err := os.MkdirAll(path.Join(dir, "work"), 0750); err != nil {
 		return fmt.Errorf("failed to set up working directory: %v", err)
 	}
-	if err := os.Mkdir(path.Join(dir, "out"), 0750); err != nil {
+	if err := os.MkdirAll(path.Join(dir, "out"), 0750); err != nil {
 		return fmt.Errorf("failed to set up working directory: %v", err)
 	}
 	return nil

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -29,7 +29,7 @@ fi
 
 DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/test}
-VERSION="1.6.0-releasebuilder.$(git rev-parse --short HEAD)"
+VERSION="1.7.0-releasebuilder.$(git rev-parse --short HEAD)"
 
 WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"


### PR DESCRIPTION
This way we avoid running `make gen-charts` only at release build script,
thus making the working tree dirty. This causes commands like `<binary> version`
to report a dirty, modified state.

This change makes sure the tree is clean before building the binaries.