### PR TITLE
Fix client-go versioning

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -100,7 +100,7 @@ func (i IstioDependencies) MarshalJSON() ([]byte, error) {
 		if dep == nil {
 			continue
 		}
-		deps[repo] = Dependency{Sha: dep.Sha}
+		deps[repo] = Dependency{Sha: dep.Sha, GoVersionEnabled: dep.GoVersionEnabled}
 	}
 	return json.Marshal(deps)
 }


### PR DESCRIPTION
Previously we intended to change the version from 1.7.0 to v1.7.0, but
we didn't actually do this.

On hold for @jasonwzm to verify we still desire this. Note - we never successfully tagged with `v` prefix