### PR TITLE
Use addon as a grafana dashboards path

### DIFF
--- a/pkg/build/grafana.go
+++ b/pkg/build/grafana.go
@@ -28,17 +28,10 @@ import (
 // Grafana packages Istio dashboards in a form that is ready to be published to grafana.com
 func Grafana(manifest model.Manifest) error {
 	if err := util.CopyDir(
-		path.Join(manifest.RepoDir("istio"), "manifests/charts/istio-telemetry/grafana/dashboards"),
+		path.Join(manifest.RepoDir("istio"), "manifests/addons/dashboards"),
 		path.Join(manifest.WorkDir(), "grafana"),
 	); err != nil {
-		// Attempt alternative directory
-		// TODO make this the only option once migration is complete
-		if err := util.CopyDir(
-			path.Join(manifest.RepoDir("istio"), "manifests/addons/dashboards"),
-			path.Join(manifest.WorkDir(), "grafana"),
-		); err != nil {
-			return err
-		}
+		return err
 	}
 	dashboards, err := ioutil.ReadDir(path.Join(manifest.WorkDir(), "grafana"))
 	if err != nil {


### PR DESCRIPTION
`istio-telemetry` directory has been removed as a part of https://github.com/istio/istio/pull/25363

Related PR: https://github.com/istio/release-builder/pull/307