### PR TITLE
Fix local build on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ The following credentials are needed
 To build locally and ensure a consistent environment, you need to have Docker installed and run the build in a docker container using a
 `gcr.io/istio-testing/build-tools` image. The exact config used, including the specific docker tag, for Istio builds can be found at
 <https://github.com/istio/test-infra/blob/master/prow/config/jobs/release-builder.yaml>. For example, the specified image might be
-`gcr.io/istio-testing/build-tools:master-2020-08-19T17-29-34`.
+`gcr.io/istio-testing/build-tools:master-2020-08-31T18-26-34`.
 
 Next, create a manifest to use for the builds. A good starting point is the `example/manifest.yaml`.
 
 Using docker, create a container using the above found `build-tools` image. On the command line you specify the commands to do the build and validate which
-point at your manifest.yaml file and also the directory specified in the manifest. An example Docker command to start the container and do a build and validate is:
+point at your manifest.yaml file and also the directory specified in the manifest.
 
 ```bash
-docker run -it -e BUILD_WITH_CONTAINER="0" -e TZ="`readlink "" /etc/localtime | sed -e 's/^.*zoneinfo\///'`" -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$(pwd),destination="/work" --mount type=volume,source=go,destination="/go" --mount type=volume,source=gocache,destination="/gocache"  -w /work gcr.io/istio-testing/build-tools:master-2020-08-19T17-29-34 /bin/bash -c "mkdir -p /tmp/istio-release; go run main.go build --manifest example/manifest.yaml; go run main.go validate --release /tmp/istio-release/out"
+./common/scripts/run.sh /bin/bash -c "mkdir -p /tmp/istio-release; go run main.go build --manifest example/manifest.yaml; go run main.go validate --release /tmp/istio-release/out"
 ```
 
 When the command finishes and you should have an information message:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following credentials are needed
 To build locally and ensure a consistent environment, you need to have Docker installed and run the build in a docker container using a
 `gcr.io/istio-testing/build-tools` image. The exact config used, including the specific docker tag, for Istio builds can be found at
 <https://github.com/istio/test-infra/blob/master/prow/config/jobs/release-builder.yaml>. For example, the specified image might be
-`gcr.io/istio-testing/build-tools:master-2020-02-14T13-09-14`.
+`gcr.io/istio-testing/build-tools:master-2020-08-19T17-29-34`.
 
 Next, create a manifest to use for the builds. A good starting point is the `example/manifest.yaml`.
 
@@ -92,7 +92,7 @@ Using docker, create a container using the above found `build-tools` image. On t
 point at your manifest.yaml file and also the directory specified in the manifest. An example Docker command to start the container and do a build and validate is:
 
 ```bash
-docker run -it -e BUILD_WITH_CONTAINER="0" -e TZ="`readlink "" /etc/localtime | sed -e 's/^.*zoneinfo\///'`" -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$(PWD),destination="/work" --mount type=volume,source=go,destination="/go" --mount type=volume,source=gocache,destination="/gocache"  -w /work gcr.io/istio-testing/build-tools:master-2020-02-14T13-09-14 /bin/bash -c "mkdir -p /tmp/istio-release; go run main.go build --manifest example/manifest.yaml; go run main.go validate --release /tmp/istio-release/out"
+docker run -it -e BUILD_WITH_CONTAINER="0" -e TZ="`readlink "" /etc/localtime | sed -e 's/^.*zoneinfo\///'`" -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=$(pwd),destination="/work" --mount type=volume,source=go,destination="/go" --mount type=volume,source=gocache,destination="/gocache"  -w /work gcr.io/istio-testing/build-tools:master-2020-08-19T17-29-34 /bin/bash -c "mkdir -p /tmp/istio-release; go run main.go build --manifest example/manifest.yaml; go run main.go validate --release /tmp/istio-release/out"
 ```
 
 When the command finishes and you should have an information message:


### PR DESCRIPTION
`$(PWD)` breaks on Linux.  Instead, use `$(pwd)` which works fine on Mac and Linux . Also updated to latest image.

```bash
bash: PWD: command not found...
Similar command is: 'pwd'
docker: Error response from daemon: invalid mount config for type "bind": field Source must not be empty.
See 'docker run --help'.
```