### PR TITLE
Update to envoy to use istio/envoy and add new dashboard

### DIFF
--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -54,5 +54,5 @@ dependencies:
     git: https://github.com/istio/tools
     branch: master
   envoy:
-    git: https://github.com/envoyproxy/envoy-wasm
+    git: https://github.com/istio/envoy
     auto: proxy_workspace

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -69,6 +69,7 @@ dependencies:
     git: https://github.com/istio/envoy
     auto: proxy_workspace
 dashboards:
+  istio-extension-dashboard: 13277
   istio-mesh-dashboard: 7639
   istio-performance-dashboard: 11829
   istio-service-dashboard: 7636

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -66,7 +66,7 @@ dependencies:
     git: https://github.com/istio/tools
     branch: master
   envoy:
-    git: https://github.com/envoyproxy/envoy-wasm
+    git: https://github.com/istio/envoy
     auto: proxy_workspace
 dashboards:
   istio-mesh-dashboard: 7639


### PR DESCRIPTION
https://github.com/istio/proxy/pull/3043 moved proxy WORKSPACE from envoy/envoy-wasm (now archived) to istio/envoy.

This should help #449.