### PR TITLE
[1.8] Cherrypick #448, GCR mirror

### DIFF
--- a/release/publish.sh
+++ b/release/publish.sh
@@ -48,3 +48,9 @@ go run main.go publish --release "${WORK_DIR}" \
     --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}" \
     --github "${GITHUB_ORG}" --githubtoken "${GITHUB_TOKEN_FILE}" \
     --grafanatoken "${GRAFANA_TOKEN_FILE}"
+
+# Also push images to a GCR repo, in case of dockerhub rate limiting issues for
+# large clusters (see https://docs.docker.com/docker-hub/download-rate-limit/).
+go run main.go publish --release "${WORK_DIR}" \
+    --dockerhub "gcr.io/istio-release" \
+    --dockertags "${VERSION}"


### PR DESCRIPTION
* Mirroring images to gcr in case of docker rate limit issues for large users.

* Changing dryrun repo to point to envoy rather than envoy-wasm

(cherry picked from commit 9546fd27930117a7d93fdd3522e4d5f9eb64374d)