### PR TITLE
fix helm manifest hub tag; fix bad merge

### DIFF
--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -72,9 +72,6 @@ func Archive(manifest model.Manifest) error {
 		if err := util.CopyDir(path.Join(manifest.RepoDir("istio"), "manifests", "charts"), manifestsDir); err != nil {
 			return err
 		}
-		if err := sanitizeHelmCharts(manifest, out); err != nil {
-			return err
-		}
 		if err := util.CopyDir(path.Join(manifest.RepoDir("istio"), "manifests", "examples"), manifestsDir); err != nil {
 			return err
 		}
@@ -123,30 +120,6 @@ func Archive(manifest model.Manifest) error {
 		if err := createStandaloneIstioctl(arch, manifest, out); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-// sanitizeHelmCharts changes the hub and tag for all helm charts in archive, except
-// the operator
-func sanitizeHelmCharts(manifest model.Manifest, out string) error {
-	if err := sanitizeTemplate(manifest, path.Join(out, "manifests/charts/istiod-remote/values.yaml")); err != nil {
-		return fmt.Errorf("failed to sanitize istiod-remote chart")
-	}
-	if err := sanitizeTemplate(manifest, path.Join(out, "manifests/charts/istio-cni/values.yaml")); err != nil {
-		return fmt.Errorf("failed to sanitize istio-cni chart")
-	}
-	if err := sanitizeTemplate(manifest, path.Join(out, "manifests/charts/gateways/istio-ingress/values.yaml")); err != nil {
-		return fmt.Errorf("failed to sanitize ingress gateway chart")
-	}
-	if err := sanitizeTemplate(manifest, path.Join(out, "manifests/charts/gateways/istio-egress/values.yaml")); err != nil {
-		return fmt.Errorf("failed to sanitize egress gateway chart")
-	}
-	if err := sanitizeTemplate(manifest, path.Join(out, "manifests/charts/istio-control/istio-discovery/values.yaml")); err != nil {
-		return fmt.Errorf("failed to sanitize istio-discovery chart")
-	}
-	if err := sanitizeTemplate(manifest, path.Join(out, "manifests/charts/base/values.yaml")); err != nil {
-		return fmt.Errorf("failed to sanitize base chart")
 	}
 	return nil
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -48,6 +48,10 @@ func Build(manifest model.Manifest) error {
 		}
 	}
 
+	if err := SanitizeAllCharts(manifest); err != nil {
+		return fmt.Errorf("failed to sanitize charts")
+	}
+
 	if _, f := manifest.BuildOutputs[model.Debian]; f {
 		if err := Debian(manifest); err != nil {
 			return fmt.Errorf("failed to build Debian: %v", err)

--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -110,7 +110,7 @@ func sanitizeChart(manifest model.Manifest, s string) error {
 	}
 
 	// Getting the current version is a bit of a hack, we should have a more explicit way to handle this
-	cv := chart["appVersion"].(string)
+	cv := chart["version"].(string)
 	if err := filepath.Walk(s, func(p string, info os.FileInfo, err error) error {
 		fname := path.Base(p)
 		if fname == "Chart.yaml" {
@@ -120,7 +120,7 @@ func sanitizeChart(manifest model.Manifest, s string) error {
 			}
 			contents := string(read)
 			// These fields contain the version, we swap out the placeholder with the correct version
-			for _, replacement := range []string{"appVersion", "version"} {
+			for _, replacement := range []string{"version"} {
 				before := fmt.Sprintf("%s: %s", replacement, cv)
 				after := fmt.Sprintf("%s: %s", replacement, manifest.Version)
 				contents = strings.ReplaceAll(contents, before, after)

--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -17,8 +17,15 @@ package build
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/ghodss/yaml"
+
+	"istio.io/pkg/log"
 
 	"istio.io/release-builder/pkg/model"
 )
@@ -35,6 +42,16 @@ var (
 
 	// Currently tags are set as `gcr.io/istio-testing` or `gcr.io/istio-release`
 	hubs = []string{"gcr.io/istio-testing", "gcr.io/istio-release"}
+
+	helmCharts = []string{
+		"manifests/charts/base",
+		"manifests/charts/gateways/istio-egress",
+		"manifests/charts/gateways/istio-ingress",
+		"manifests/charts/istio-cni",
+		"manifests/charts/istio-control/istio-discovery/",
+		"manifests/charts/istio-operator",
+		"manifests/charts/istiod-remote",
+	}
 )
 
 // Similar to sanitizeChart, but works on generic templates rather than only Helm charts.
@@ -63,5 +80,64 @@ func sanitizeTemplate(manifest model.Manifest, p string) error {
 		return err
 	}
 
+	return nil
+}
+
+// SanitizeAllCharts rewrites versions, tags, and hubs for helm charts. This is done independent of Helm
+// as it is required for both the helm charts and the archive
+func SanitizeAllCharts(manifest model.Manifest) error {
+	for _, chart := range helmCharts {
+		if err := sanitizeChart(manifest, path.Join(manifest.RepoDir("istio"), chart)); err != nil {
+			return fmt.Errorf("failed to sanitze chart %v: %v", chart, err)
+		}
+	}
+	return nil
+}
+
+// In the final published charts, we need the version and tag to be set for the appropriate version
+// In order to do this, we simply replace the current version with the new one.
+func sanitizeChart(manifest model.Manifest, s string) error {
+	// TODO improve this to not use raw string handling of yaml
+	currentVersion, err := ioutil.ReadFile(path.Join(s, "Chart.yaml"))
+	if err != nil {
+		return err
+	}
+
+	chart := make(map[string]interface{})
+	if err := yaml.Unmarshal(currentVersion, &chart); err != nil {
+		log.Errorf("unmarshal failed for Chart.yaml: %v", string(currentVersion))
+		return fmt.Errorf("failed to unmarshal chart: %v", err)
+	}
+
+	// Getting the current version is a bit of a hack, we should have a more explicit way to handle this
+	cv := chart["appVersion"].(string)
+	if err := filepath.Walk(s, func(p string, info os.FileInfo, err error) error {
+		fname := path.Base(p)
+		if fname == "Chart.yaml" {
+			read, err := ioutil.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			contents := string(read)
+			// These fields contain the version, we swap out the placeholder with the correct version
+			for _, replacement := range []string{"appVersion", "version"} {
+				before := fmt.Sprintf("%s: %s", replacement, cv)
+				after := fmt.Sprintf("%s: %s", replacement, manifest.Version)
+				contents = strings.ReplaceAll(contents, before, after)
+			}
+
+			err = ioutil.WriteFile(p, []byte(contents), 0)
+			if err != nil {
+				return err
+			}
+
+			if err := sanitizeTemplate(manifest, p); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -113,7 +113,7 @@ func sanitizeChart(manifest model.Manifest, s string) error {
 	cv := chart["version"].(string)
 	if err := filepath.Walk(s, func(p string, info os.FileInfo, err error) error {
 		fname := path.Base(p)
-		if fname == "Chart.yaml" {
+		if fname == "Chart.yaml" || fname == "values.yaml" {
 			read, err := ioutil.ReadFile(p)
 			if err != nil {
 				return err

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -282,7 +282,6 @@ func TestHelmVersionsIstio(r ReleaseInfo) error {
 		"manifests/charts/gateways/istio-ingress/values.yaml",
 		"manifests/charts/istio-cni/values.yaml",
 		"manifests/charts/istio-control/istio-discovery/values.yaml",
-		"manifests/charts/istio-operator/values.yaml",
 		"manifests/charts/istiod-remote/values.yaml",
 	}
 	for _, f := range checks {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -293,17 +293,17 @@ func TestHelmVersionsIstio(r ReleaseInfo) error {
 		}
 		tag, err := GenericMap{values}.Path([]string{"global", "tag"})
 		if err != nil {
-			return fmt.Errorf("invalid path: %v", err)
+			return fmt.Errorf("invalid path: %v: %v", f, err)
 		}
 		if tag != r.manifest.Version {
-			return fmt.Errorf("archive tag incorrect, got %v expected %v", tag, r.manifest.Version)
+			return fmt.Errorf("archive tag incorrect: %v: got %v expected %v", f, tag, r.manifest.Version)
 		}
 		hub, err := GenericMap{values}.Path([]string{"global", "hub"})
 		if err != nil {
-			return fmt.Errorf("invalid path: %v", err)
+			return fmt.Errorf("invalid path: %v: %v", f,err)
 		}
 		if hub != r.manifest.Docker {
-			return fmt.Errorf("hub incorrect, got %v expected %v", hub, r.manifest.Docker)
+			return fmt.Errorf("hub incorrect: %v: got %v expected %v", f, hub, r.manifest.Docker)
 		}
 	}
 	return nil

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -76,6 +76,7 @@ func CheckRelease(release string) ([]string, string, []error) {
 		"IstioctlArchive":      TestIstioctlArchive,
 		"IstioctlStandalone":   TestIstioctlStandalone,
 		"TestDocker":           TestDocker,
+		"HelmVersionsIstio":    TestHelmVersionsIstio,
 		"HelmVersionsOperator": TestHelmVersionsOperator,
 		"Manifest":             TestManifest,
 		"Licenses":             TestLicenses,
@@ -272,6 +273,39 @@ func TestProxyVersion(r ReleaseInfo) error {
 		return fmt.Errorf("did not find proxy version variable")
 	}
 
+	return nil
+}
+
+func TestHelmVersionsIstio(r ReleaseInfo) error {
+	checks := []string{
+		"manifests/charts/base/values.yaml",
+		"manifests/charts/gateways/istio-egress/values.yaml",
+		"manifests/charts/gateways/istio-ingress/values.yaml",
+		"manifests/charts/istio-cni/values.yaml",
+		"manifests/charts/istio-control/istio-discovery/values.yaml",
+		"manifests/charts/istio-operator/values.yaml",
+		"manifests/charts/istiod-remote/values.yaml",
+	}
+	for _, f := range checks {
+		values, err := getValues(filepath.Join(r.archive, f))
+		if err != nil {
+			return err
+		}
+		tag, err := GenericMap{values}.Path([]string{"global", "tag"})
+		if err != nil {
+			return fmt.Errorf("invalid path: %v", err)
+		}
+		if tag != r.manifest.Version {
+			return fmt.Errorf("archive tag incorrect, got %v expected %v", tag, r.manifest.Version)
+		}
+		hub, err := GenericMap{values}.Path([]string{"global", "hub"})
+		if err != nil {
+			return fmt.Errorf("invalid path: %v", err)
+		}
+		if hub != r.manifest.Docker {
+			return fmt.Errorf("hub incorrect, got %v expected %v", hub, r.manifest.Docker)
+		}
+	}
 	return nil
 }
 

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -299,7 +299,7 @@ func TestHelmVersionsIstio(r ReleaseInfo) error {
 		}
 		hub, err := GenericMap{values}.Path([]string{"global", "hub"})
 		if err != nil {
-			return fmt.Errorf("invalid path: %v: %v", f,err)
+			return fmt.Errorf("invalid path: %v: %v", f, err)
 		}
 		if hub != r.manifest.Docker {
 			return fmt.Errorf("hub incorrect: %v: got %v expected %v", f, hub, r.manifest.Docker)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -278,7 +278,6 @@ func TestProxyVersion(r ReleaseInfo) error {
 
 func TestHelmVersionsIstio(r ReleaseInfo) error {
 	checks := []string{
-		"manifests/charts/base/values.yaml",
 		"manifests/charts/gateways/istio-egress/values.yaml",
 		"manifests/charts/gateways/istio-ingress/values.yaml",
 		"manifests/charts/istio-cni/values.yaml",


### PR DESCRIPTION
A couple of issues:

Fix bad merge in #507. @howardjohn asked me to use 1.4 sanitization methods.

This PR reverts my PR and uses the code from 1.4 with changes made to manifests/