### PR TITLE
Add validation for helm operator manifest

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -312,7 +312,7 @@ func validateHubTag(r ReleaseInfo, file string, paths string) error {
 	}
 	hubPath := []string{paths, "hub"}
 	if paths == "" {
-		tagPath = []string{"hub"}
+		hubPath = []string{"hub"}
 	}
 	hub, err := GenericMap{values}.Path(hubPath)
 	if err != nil {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -299,14 +299,22 @@ func validateHubTag(r ReleaseInfo, file string, paths string) error {
 	if err != nil {
 		return err
 	}
-	tag, err := GenericMap{values}.Path([]string{paths, "tag"})
+	tagPath := []string{paths, "tag"}
+	if paths == "" {
+		tagPath = []string{"tag"}
+	}
+	tag, err := GenericMap{values}.Path(tagPath)
 	if err != nil {
 		return fmt.Errorf("invalid path (%v): %v", file, err)
 	}
 	if tag != r.manifest.Version {
 		return fmt.Errorf("archive tag incorrect (%v): got %v expected %v", file, tag, r.manifest.Version)
 	}
-	hub, err := GenericMap{values}.Path([]string{paths, "hub"})
+	hubPath := []string{paths, "hub"}
+	if paths == "" {
+		tagPath = []string{"hub"}
+	}
+	hub, err := GenericMap{values}.Path(hubPath)
 	if err != nil {
 		return fmt.Errorf("invalid path (%v): %v", file, err)
 	}


### PR DESCRIPTION
The manifest for helm/operator does not use global.hub and global.tag. Instead it is specified at the top level.

Make sure the hub and tag are set appropriately

Fixes https://github.com/istio/istio/issues/26920