### PR TITLE
Add GitHub token to to allow commits in build subcommand

### DIFF
--- a/pkg/branch/branch.go
+++ b/pkg/branch/branch.go
@@ -31,7 +31,7 @@ import (
 // multiple items which can be done before another item has a dependency
 // on an intem in the given step.
 // This function assumes the working directory has been setup and sources resolved.
-func Branch(manifest model.Manifest, step int, dryrun bool) error {
+func Branch(manifest model.Manifest, step int, dryrun bool, token string) error {
 	if err := writeManifest(manifest, manifest.OutDir()); err != nil {
 		return fmt.Errorf("failed to write manifest: %v", err)
 	}
@@ -92,7 +92,7 @@ func Branch(manifest model.Manifest, step int, dryrun bool) error {
 			prName = "[release-" + release + "] " + prName
 		}
 		if err := util.CreatePR(manifest, repo, "automatedBranchStep"+strconv.Itoa(step),
-			prName, dryrun); err != nil {
+			prName, dryrun, token); err != nil {
 			return fmt.Errorf("failed PR creation: %v", err)
 		}
 	}

--- a/pkg/branch/cmd.go
+++ b/pkg/branch/cmd.go
@@ -21,13 +21,15 @@ import (
 
 	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg"
+	"istio.io/release-builder/pkg/util"
 )
 
 var (
 	flags = struct {
-		manifest string
-		dryrun   bool
-		step     int
+		manifest        string
+		dryrun          bool
+		step            int
+		githubTokenFile string
 	}{
 		manifest: "example/manifest_branch.yaml",
 		dryrun:   true, // Default to dry-run for now
@@ -61,7 +63,12 @@ var (
 			}
 			log.Infof("Fetched all sources and setup working directory at %v", manifest.WorkDir())
 
-			if err := Branch(manifest, flags.step, flags.dryrun); err != nil {
+			token, err := util.GetGithubToken(flags.githubTokenFile)
+			if err != nil {
+				return err
+			}
+
+			if err := Branch(manifest, flags.step, flags.dryrun, token); err != nil {
 				return fmt.Errorf("failed to branch: %v", err)
 			}
 
@@ -78,6 +85,8 @@ func init() {
 		"Do not run any github commands.")
 	branchCmd.PersistentFlags().IntVar(&flags.step, "step", flags.step,
 		"Which step to run.")
+	branchCmd.PersistentFlags().StringVar(&flags.githubTokenFile, "githubtoken", flags.githubTokenFile,
+		"The file containing a github token.")
 }
 
 func GetBranchCommand() *cobra.Command {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,9 +30,9 @@ import (
 
 // Build will create all artifacts required by the manifest
 // This assumes the working directory has been setup and sources resolved.
-func Build(manifest model.Manifest) error {
+func Build(manifest model.Manifest, githubToken string) error {
 	if _, f := manifest.BuildOutputs[model.Scanner]; f {
-		if err := Scanner(manifest); err != nil {
+		if err := Scanner(manifest, githubToken); err != nil {
 			return fmt.Errorf("failed image scan: %v", err)
 		}
 	}

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -21,11 +21,13 @@ import (
 
 	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg"
+	"istio.io/release-builder/pkg/util"
 )
 
 var (
 	flags = struct {
-		manifest string
+		manifest        string
+		githubTokenFile string
 	}{
 		manifest: "example/manifest.yaml",
 	}
@@ -58,7 +60,12 @@ var (
 				return fmt.Errorf("failed to standardize manifest: %v", err)
 			}
 
-			if err := Build(manifest); err != nil {
+			token, err := util.GetGithubToken(flags.githubTokenFile)
+			if err != nil {
+				return err
+			}
+
+			if err := Build(manifest, token); err != nil {
 				return fmt.Errorf("failed to build: %v", err)
 			}
 
@@ -71,6 +78,8 @@ var (
 func init() {
 	buildCmd.PersistentFlags().StringVar(&flags.manifest, "manifest", flags.manifest,
 		"The manifest to build.")
+	buildCmd.PersistentFlags().StringVar(&flags.githubTokenFile, "githubtoken", flags.githubTokenFile,
+		"The file containing a github token.")
 }
 
 func GetBuildCommand() *cobra.Command {

--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -42,7 +42,7 @@ type Results struct {
 }
 
 // Scanner checks the base image for any CVEs.
-func Scanner(manifest model.Manifest) error {
+func Scanner(manifest model.Manifest, githubToken string) error {
 	// Retrieve BASE_VERSION from the istio/istio Makefile
 	istioDir := manifest.RepoDir("istio")
 	var out bytes.Buffer
@@ -133,7 +133,7 @@ func Scanner(manifest model.Manifest) error {
 	}
 
 	if err := util.CreatePR(manifest, "istio", "newBaseVersion"+newBaseVersion,
-		"Update BASE_VERSION to "+newBaseVersion, false); err != nil {
+		"Update BASE_VERSION to "+newBaseVersion, false, githubToken); err != nil {
 		return fmt.Errorf("failed PR creation: %v", err)
 	}
 

--- a/pkg/publish/cmd.go
+++ b/pkg/publish/cmd.go
@@ -106,7 +106,7 @@ func Publish(manifest model.Manifest) error {
 		}
 	}
 	if flags.github != "" {
-		token, err := getGithubToken(flags.githubtoken)
+		token, err := util.GetGithubToken(flags.githubtoken)
 		if err != nil {
 			return err
 		}
@@ -136,15 +136,4 @@ func getGrafanaToken(file string) (string, error) {
 		return strings.TrimSpace(string(b)), nil
 	}
 	return os.Getenv("GRAFANA_TOKEN"), nil
-}
-
-func getGithubToken(file string) (string, error) {
-	if file != "" {
-		b, err := ioutil.ReadFile(file)
-		if err != nil {
-			return "", fmt.Errorf("failed to read github token: %v", file)
-		}
-		return strings.TrimSpace(string(b)), nil
-	}
-	return os.Getenv("GITHUB_TOKEN"), nil
 }


### PR DESCRIPTION
The build command fails to create a PR to use the new build image (after building new images if the image scan fails):
```
2021-03-19T16:42:12.030286Z	info	Running command: git checkout -b newBaseVersion1.9-dev.5
Switched to a new branch 'newBaseVersion1.9-dev.5'
M	Makefile.core.mk
2021-03-19T16:42:12.058310Z	info	Running command: git add -A
2021-03-19T16:42:12.096769Z	info	Running command: git commit -m Update BASE_VERSION to 1.9-dev.5

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'root@ac4e818d-88d1-11eb-830a-0e97a6c789f3.(none)')
Error: failed to build: failed image scan: failed PR creation: exit status 128
exit status 1
```
This PR adds code such that the GitHub token will be read from the GITHUB_TOKEN env var or can be specified as a flag on the command line, and will use that to get the user name and email and set them on the `git commit` command line.
