### PR TITLE
CP #594 - Add GitHub token to to allow commits in build subcommand

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -24,16 +24,15 @@ import (
 	"github.com/ghodss/yaml"
 
 	"istio.io/pkg/log"
-
 	"istio.io/release-builder/pkg/model"
 	"istio.io/release-builder/pkg/util"
 )
 
 // Build will create all artifacts required by the manifest
 // This assumes the working directory has been setup and sources resolved.
-func Build(manifest model.Manifest) error {
+func Build(manifest model.Manifest, githubToken string) error {
 	if _, f := manifest.BuildOutputs[model.Scanner]; f {
-		if err := Scanner(manifest); err != nil {
+		if err := Scanner(manifest, githubToken); err != nil {
 			return fmt.Errorf("failed image scan: %v", err)
 		}
 	}

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -19,14 +19,15 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"istio.io/release-builder/pkg"
-
 	"istio.io/pkg/log"
+	"istio.io/release-builder/pkg"
+	"istio.io/release-builder/pkg/util"
 )
 
 var (
 	flags = struct {
-		manifest string
+		manifest        string
+		githubTokenFile string
 	}{
 		manifest: "example/manifest.yaml",
 	}
@@ -59,7 +60,12 @@ var (
 				return fmt.Errorf("failed to standardize manifest: %v", err)
 			}
 
-			if err := Build(manifest); err != nil {
+			token, err := util.GetGithubToken(flags.githubTokenFile)
+			if err != nil {
+				return err
+			}
+
+			if err := Build(manifest, token); err != nil {
 				return fmt.Errorf("failed to build: %v", err)
 			}
 
@@ -72,6 +78,8 @@ var (
 func init() {
 	buildCmd.PersistentFlags().StringVar(&flags.manifest, "manifest", flags.manifest,
 		"The manifest to build.")
+	buildCmd.PersistentFlags().StringVar(&flags.githubTokenFile, "githubtoken", flags.githubTokenFile,
+		"The file containing a github token.")
 }
 
 func GetBuildCommand() *cobra.Command {

--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -42,7 +42,7 @@ type Results struct {
 }
 
 // Scanner checks the base image for any CVEs.
-func Scanner(manifest model.Manifest) error {
+func Scanner(manifest model.Manifest, githubToken string) error {
 	// Retrieve BASE_VERSION from the istio/istio Makefile
 	istioDir := manifest.RepoDir("istio")
 	var out bytes.Buffer
@@ -133,7 +133,7 @@ func Scanner(manifest model.Manifest) error {
 	}
 
 	if err := util.CreatePR(manifest, "istio", "newBaseVersion"+newBaseVersion,
-		"Update BASE_VERSION to "+newBaseVersion, false); err != nil {
+		"Update BASE_VERSION to "+newBaseVersion, false, githubToken); err != nil {
 		return fmt.Errorf("failed PR creation: %v", err)
 	}
 

--- a/pkg/publish/cmd.go
+++ b/pkg/publish/cmd.go
@@ -23,11 +23,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg"
 	"istio.io/release-builder/pkg/model"
 	"istio.io/release-builder/pkg/util"
-
-	"istio.io/pkg/log"
 )
 
 var (
@@ -107,7 +106,7 @@ func Publish(manifest model.Manifest) error {
 		}
 	}
 	if flags.github != "" {
-		token, err := getGithubToken(flags.githubtoken)
+		token, err := util.GetGithubToken(flags.githubtoken)
 		if err != nil {
 			return err
 		}
@@ -137,14 +136,4 @@ func getGrafanaToken(file string) (string, error) {
 		return strings.TrimSpace(string(b)), nil
 	}
 	return os.Getenv("GRAFANA_TOKEN"), nil
-}
-func getGithubToken(file string) (string, error) {
-	if file != "" {
-		b, err := ioutil.ReadFile(file)
-		if err != nil {
-			return "", fmt.Errorf("failed to read github token: %v", file)
-		}
-		return strings.TrimSpace(string(b)), nil
-	}
-	return os.Getenv("GITHUB_TOKEN"), nil
 }


### PR DESCRIPTION
This is a manual cherry-pick of #594. The release-1.9 branch does not contain the `branch` command so those changes are not cherry-picked.