### PR TITLE
Fix bug causing incorrect version parsing from envvar

### DIFF
--- a/release/branch.sh
+++ b/release/branch.sh
@@ -38,9 +38,9 @@ fi
 BASE_BRANCH=${BASE_BRANCH:-${base_branch}}
 
 MANIFEST=$(cat <<EOF
-version: ${VERSION}
-docker: ${DOCKER_HUB}
-directory: ${WORK_DIR}
+version: "${VERSION}"
+docker: "${DOCKER_HUB}"
+directory: "${WORK_DIR}"
 dependencies:
 ${DEPENDENCIES:-$(cat <<EOD
   istio:

--- a/release/build.sh
+++ b/release/build.sh
@@ -43,9 +43,9 @@ WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"
 
 MANIFEST=$(cat <<EOF
-version: ${VERSION}
-docker: ${DOCKER_HUB}
-directory: ${WORK_DIR}
+version: "${VERSION}"
+docker: "${DOCKER_HUB}"
+directory: "${WORK_DIR}"
 dependencies:
 ${DEPENDENCIES:-$(cat <<EOD
   istio:


### PR DESCRIPTION
Prevents manifests with `version: 1.10` from unmarshalling as `1.1`