### PR TITLE
Point 1.10 release-builder to envoyproxy/envoy

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -74,7 +74,7 @@ ${DEPENDENCIES:-$(cat <<EOD
     git: https://github.com/istio/tools
     branch: release-1.10
   envoy:
-    git: https://github.com/istio/envoy
+    git: https://github.com/envoyproxy/envoy
     auto: proxy_workspace
 EOD
 )}


### PR DESCRIPTION
Temporary measure until Envoy cuts release 1.18.0, at which point we need to force-update `istio/envoy` release-1.10 from that release