### PR TITLE
[release-1.9] Manual CP of #615 - Add GH token

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -37,6 +37,8 @@ fi
 # We shouldn't push here right now, this is just which version to embed in the Helm charts
 DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
 
+GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE:-}
+
 VERSION="$(cat "${WD}/trigger-build")"
 
 WORK_DIR="$(mktemp -d)/build"
@@ -93,6 +95,6 @@ EOF
 # "Temporary" hacks
 export PATH=${GOPATH}/bin:${PATH}
 
-go run main.go build --manifest <(echo "${MANIFEST}")
+go run main.go build --manifest <(echo "${MANIFEST}") --githubtoken "${GITHUB_TOKEN_FILE}"
 go run main.go validate --release "${WORK_DIR}/out"
 go run main.go publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --dockerhub "${PRERELEASE_DOCKER_HUB}" --dockertags "${VERSION}"


### PR DESCRIPTION
Manual CP of #615. This is needed to allow creation of PR after new base images are built. Needs a manual CP since there is no branch logic in 1.9 and 1.8 (automated CP would fail since some of the changes couldn't be CP'd as files aren't there).