### PR TITLE
skip istio/envoy in createBranches branching step

### DIFF
--- a/pkg/branch/createBranches.go
+++ b/pkg/branch/createBranches.go
@@ -32,8 +32,9 @@ func CreateBranches(manifest model.Manifest, release string, dryrun bool) error 
 			log.Infof("skipping missing dependency: %v", repo)
 			continue
 		}
-		// Skip particular repos
-		if repo == "test-infra" {
+		// test-infra does not use release branches and envoy repo should be manually branched
+		// from correct envoy commit
+		if repo == "test-infra" || repo == "envoy" {
 			log.Infof("Skipping repo: %v", repo)
 			continue
 		}


### PR DESCRIPTION
istio/envoy should be manually branched from the correct envoyproxy/envoy version, not branched from istio/envoy master branch