### PR TITLE
Point build.sh back at istio/envoy

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -76,7 +76,7 @@ ${DEPENDENCIES:-$(cat <<EOD
     git: https://github.com/istio/tools
     branch: release-1.10
   envoy:
-    git: https://github.com/envoyproxy/envoy
+    git: https://github.com/istio/envoy
     auto: proxy_workspace
 EOD
 )}

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -66,7 +66,7 @@ dependencies:
     git: https://github.com/istio/tools
     branch: release-1.10
   envoy:
-    git: https://github.com/envoyproxy/envoy
+    git: https://github.com/istio/envoy
     auto: proxy_workspace
 dashboards:
   istio-extension-dashboard: 13277


### PR DESCRIPTION
Since we've [manually brought istio/envoy release-1.10 up to date with envoyproxy/envoy](https://github.com/istio/proxy/pull/3287) we can and should use `istio/envoy` for the builds now.