### PR TITLE
Update to use Trivy

### DIFF
--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -52,7 +52,7 @@ func Scanner(manifest model.Manifest, githubToken string) error {
 
 	// Call imagescanner passing in base image name. If request times out, retry the request
 	baseImageName := "istio/base:" + baseVersion
-	cmd := util.VerboseCommand("trivy", "--ignore-unfixed", "--exit-code", "2", baseImageName)
+	cmd := util.VerboseCommand("trivy", "--ignore-unfixed", "--no-progress", "--exit-code", "2", baseImageName)
 	if err = cmd.Run(); err != nil {
 		// There were either vulnerabilities or an issue running the scaner. Output message listing vulnerabilities.
 		log.Infof("Base image scan of %s failed with:\n %s", baseImageName, err.Error())

--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -52,12 +52,10 @@ func Scanner(manifest model.Manifest, githubToken string) error {
 
 	// Call imagescanner passing in base image name. If request times out, retry the request
 	baseImageName := "istio/base:" + baseVersion
-	cmd := exec.Command("trivy", "--ignore-unfixed", baseImageName)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd := util.VerboseCommand("trivy", "--ignore-unfixed", "--exit-code", "2", baseImageName)
 	if err = cmd.Run(); err != nil {
-		// There were vulnerabilities. Output message listing vulnerabilities.
-		log.Infof("Base image scan of %s failed with:\n %s", baseImageName, string(err.Error()))
+		// There were either vulnerabilities or an issue running the scaner. Output message listing vulnerabilities.
+		log.Infof("Base image scan of %s failed with:\n %s", baseImageName, err.Error())
 	}
 
 	// If IgnoreVulernability is true, just just return


### PR DESCRIPTION
This updates our release builder tooling to use trivy instead of IBM's image scanner. 

`ignoreVulnerability` is true, but a test run of this can be seen in the output of `dry-run_release-builder`