### PR TITLE
Update to use Trivy (#687)

### DIFF
--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -16,11 +16,7 @@ package build
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net"
-	"net/http"
 	"os"
 	"os/exec"
 	"strconv"
@@ -56,43 +52,11 @@ func Scanner(manifest model.Manifest, githubToken string) error {
 
 	// Call imagescanner passing in base image name. If request times out, retry the request
 	baseImageName := "istio/base:" + baseVersion
-	numberRetries := 4
-	var resp *http.Response
-	for numberRetries > 0 {
-		resp, err = http.Get("http://imagescanner.cloud.ibm.com/scan?image=" + strings.TrimSpace(baseImageName))
-		if err != nil {
-			if err, ok := err.(net.Error); ok && err.Timeout() {
-				fmt.Println("Scanner request timed out. Need to run request again.")
-			} else {
-				return err
-			}
-		}
-		numberRetries--
+	cmd := util.VerboseCommand("trivy", "--ignore-unfixed", "--no-progress", "--exit-code", "2", baseImageName)
+	if err = cmd.Run(); err != nil {
+		// There were either vulnerabilities or an issue running the scaner. Output message listing vulnerabilities.
+		log.Infof("Base image scan of %s failed with:\n %s", baseImageName, err.Error())
 	}
-	if err != nil {
-		return err
-	}
-
-	// Check response for OK
-	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
-	var response Response
-	if err := json.Unmarshal(body, &response); err != nil {
-		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		if (resp.StatusCode) == http.StatusInternalServerError {
-			return fmt.Errorf("scanning error (%s): %s", baseImageName, response.Progress)
-		}
-		return fmt.Errorf("scanning error (%s): %d", baseImageName, resp.StatusCode)
-	}
-	if response.Results.Status == "OK" {
-		log.Infof("Base image scan of %s was successful", baseImageName)
-		return nil
-	}
-
-	// There were vulnerabilities. Output message listing vulnerabilities.
-	log.Infof("Base image scan of %s failed with:\n %s", baseImageName, string(body))
 
 	// If IgnoreVulernability is true, just just return
 	if manifest.IgnoreVulnerability {
@@ -115,7 +79,7 @@ func Scanner(manifest model.Manifest, githubToken string) error {
 		"HUBS=docker.io/istio gcr.io/istio-release",
 		"TAG=" + newBaseVersion,
 	}
-	cmd := util.VerboseCommand("tools/build-base-images.sh")
+	cmd = util.VerboseCommand("tools/build-base-images.sh")
 	cmd.Env = util.StandardEnv(manifest)
 	cmd.Env = append(cmd.Env, buildImageEnv...)
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This is a manual cherry-pick of #687.

This replaces the IBM vulnerability scanner with the Trivy vulnerability scanner for our base images. 

> We compared Docker scan, Trivy and the IBM scanner. Trivy and docker scan caught quite a bit more than the IBM scanner and Trivy was significantly faster with output that was quite a bit more readable. I also had some rate limiting issues with Docker which won't occur with Trivy given that it runs locally.