### PR TITLE
Fix issue where manifest dependencies are SHAs during build

### DIFF
--- a/pkg/branch/branch.go
+++ b/pkg/branch/branch.go
@@ -92,7 +92,7 @@ func Branch(manifest model.Manifest, step int, dryrun bool, token string) error 
 			prName = "[release-" + release + "] " + prName
 		}
 		if err := util.CreatePR(manifest, repo, "automatedBranchStep"+strconv.Itoa(step),
-			prName, dryrun, token); err != nil {
+			prName, dryrun, token, "", ""); err != nil {
 			return fmt.Errorf("failed PR creation: %v", err)
 		}
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -31,7 +31,6 @@ import (
 // Build will create all artifacts required by the manifest
 // This assumes the working directory has been setup and sources resolved.
 func Build(manifest model.Manifest, githubToken string) error {
-
 	if _, f := manifest.BuildOutputs[model.Docker]; f {
 		if err := Docker(manifest); err != nil {
 			return fmt.Errorf("failed to build Docker: %v", err)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -31,15 +31,6 @@ import (
 // Build will create all artifacts required by the manifest
 // This assumes the working directory has been setup and sources resolved.
 func Build(manifest model.Manifest, githubToken string) error {
-	if _, f := manifest.BuildOutputs[model.Scanner]; f {
-		if err := Scanner(manifest, githubToken); err != nil {
-			if manifest.IgnoreVulnerability {
-				log.Infof("Ignoring vulnerability scanning error: %v", err)
-			} else {
-				return fmt.Errorf("failed image scan: %v", err)
-			}
-		}
-	}
 
 	if _, f := manifest.BuildOutputs[model.Docker]; f {
 		if err := Docker(manifest); err != nil {


### PR DESCRIPTION
Looking at the release-builder failure: 

https://storage.googleapis.com/istio-prow/logs/build-release_release-builder_release-1.10_postsubmit/1415393564543684608/build-log.txt

There are 2 issues: The first is that the `trivy` command found no issues so we shouldn't have tried building new images and create the PR for them. This problem was fixed in  https://github.com/istio/release-builder/pull/707.

The second issue was the failing `panic: runtime error: index out of range [-1]`

Looking at the code, I see that we attempt to use the `istio` manifest dependency and get the `git url` and `branch`to create the PR. This fails in the case of the build because they were overriden by the `StandardizeManifest` call replacing them with the SHA of the head of the git url and branch.

The new code saves the git url and branch from the input manifest, and passes them along as parameters. In the `createPR` method we check if they are blank (this happens in the case of branching), and then set them from the manifest (branching does not Standardize the manifest).

I did move the Scanner call to the command from the build only to prevent having to pass the new parts on the build call.  