### PR TITLE
[release-1.9] Manual cherry-pick of #721

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -31,16 +31,6 @@ import (
 // Build will create all artifacts required by the manifest
 // This assumes the working directory has been setup and sources resolved.
 func Build(manifest model.Manifest, githubToken string) error {
-	if _, f := manifest.BuildOutputs[model.Scanner]; f {
-		if err := Scanner(manifest, githubToken); err != nil {
-			if manifest.IgnoreVulnerability {
-				log.Infof("Ignoring vulnerability scanning error: %v", err)
-			} else {
-				return fmt.Errorf("failed image scan: %v", err)
-			}
-		}
-	}
-
 	if _, f := manifest.BuildOutputs[model.Docker]; f {
 		if err := Docker(manifest); err != nil {
 			return fmt.Errorf("failed to build Docker: %v", err)


### PR DESCRIPTION
  Fix issue where manifest dependencies are SHAs during build

This should allow the PR to be created when new base images are built so you don't have to. Just approve the one created.