### PR TITLE
Add build+publish of a helm repo

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -40,6 +40,11 @@ func Build(manifest model.Manifest, githubToken string) error {
 	if err := SanitizeAllCharts(manifest); err != nil {
 		return fmt.Errorf("failed to sanitize charts: %v", err)
 	}
+	if _, f := manifest.BuildOutputs[model.Helm]; f {
+		if err := HelmCharts(manifest); err != nil {
+			return fmt.Errorf("failed to build HelmCharts: %v", err)
+		}
+	}
 
 	if _, f := manifest.BuildOutputs[model.Debian]; f {
 		if err := Debian(manifest); err != nil {
@@ -85,7 +90,7 @@ func Build(manifest model.Manifest, githubToken string) error {
 
 // writeLicense copies the complete list of licenses for all dependant repos
 func writeLicense(manifest model.Manifest) error {
-	if err := os.MkdirAll(filepath.Join(manifest.OutDir(), "licenses"), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Join(manifest.OutDir(), "licenses"), 0o750); err != nil {
 		return fmt.Errorf("failed to create license dir: %v", err)
 	}
 	for repo := range manifest.Dependencies.Get() {
@@ -111,7 +116,7 @@ func writeManifest(manifest model.Manifest, dir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %v", err)
 	}
-	if err := ioutil.WriteFile(path.Join(dir, "manifest.yaml"), yml, 0640); err != nil {
+	if err := ioutil.WriteFile(path.Join(dir, "manifest.yaml"), yml, 0o640); err != nil {
 		return fmt.Errorf("failed to write manifest: %v", err)
 	}
 	return nil

--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -158,7 +158,7 @@ func HelmCharts(manifest model.Manifest) error {
 	if err := os.MkdirAll(path.Join(dst), 0o750); err != nil {
 		return fmt.Errorf("failed to make destination directory %v: %v", dst, err)
 	}
-	for _, chart := range helmCharts {
+	for _, chart := range repoHelmCharts {
 		dir := path.Join(manifest.RepoDir("istio"), chart)
 		c := util.VerboseCommand("helm", "package", dir)
 		c.Dir = dst

--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -27,6 +27,7 @@ import (
 
 	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg/model"
+	"istio.io/release-builder/pkg/util"
 )
 
 var (
@@ -137,6 +138,22 @@ func sanitizeChart(manifest model.Manifest, s string) error {
 		return nil
 	}); err != nil {
 		return err
+	}
+	return nil
+}
+
+func HelmCharts(manifest model.Manifest) error {
+	dst := path.Join(manifest.OutDir(), "helm")
+	if err := os.MkdirAll(path.Join(dst), 0o750); err != nil {
+		return fmt.Errorf("failed to make destination directory %v: %v", dst, err)
+	}
+	for _, chart := range helmCharts {
+		dir := path.Join(manifest.RepoDir("istio"), chart)
+		c := util.VerboseCommand("helm", "package", dir)
+		c.Dir = dst
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("package %v: %v", chart, err)
+		}
 	}
 	return nil
 }

--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -43,14 +43,25 @@ var (
 	// Currently tags are set as `gcr.io/istio-testing` or `gcr.io/istio-release`
 	hubs = []string{"gcr.io/istio-testing", "gcr.io/istio-release"}
 
+	// helmCharts contains all helm charts we will release
 	helmCharts = []string{
 		"manifests/charts/base",
+		"manifests/charts/gateway",
 		"manifests/charts/gateways/istio-egress",
 		"manifests/charts/gateways/istio-ingress",
 		"manifests/charts/istio-cni",
-		"manifests/charts/istio-control/istio-discovery/",
+		"manifests/charts/istio-control/istio-discovery",
 		"manifests/charts/istio-operator",
 		"manifests/charts/istiod-remote",
+	}
+
+	// repoHelmCharts contains all helm charts we will release to the helm repo. This is a subset of
+	// helmCharts as we want to only publish our fully supported charts.
+	repoHelmCharts = []string{
+		"manifests/charts/base",
+		"manifests/charts/gateway",
+		"manifests/charts/istio-cni",
+		"manifests/charts/istio-control/istio-discovery",
 	}
 )
 

--- a/pkg/publish/cmd.go
+++ b/pkg/publish/cmd.go
@@ -35,6 +35,7 @@ var (
 		dockerhub    string
 		dockertags   []string
 		gcsbucket    string
+		helmbucket   string
 		gcsaliases   []string
 		github       string
 		githubtoken  string
@@ -72,7 +73,9 @@ func init() {
 	publishCmd.PersistentFlags().StringSliceVar(&flags.dockertags, "dockertags", flags.dockertags,
 		"The tags to apply to docker images. Example: latest")
 	publishCmd.PersistentFlags().StringVar(&flags.gcsbucket, "gcsbucket", flags.gcsbucket,
-		"The gcs bucket to publish binaries to. Example: gs://istio-release.")
+		"The gcs bucket to publish binaries to. Example: istio-release/releases.")
+	publishCmd.PersistentFlags().StringVar(&flags.helmbucket, "helmbucket", flags.helmbucket,
+		"The gcs bucket to publish helm to. Example: istio-release/charts.")
 	publishCmd.PersistentFlags().StringSliceVar(&flags.gcsaliases, "gcsaliases", flags.gcsaliases,
 		"Alias to publish to gcs. Example: latest")
 	publishCmd.PersistentFlags().StringVar(&flags.github, "github", flags.github,
@@ -103,6 +106,11 @@ func Publish(manifest model.Manifest) error {
 	if flags.gcsbucket != "" {
 		if err := GcsArchive(manifest, flags.gcsbucket, flags.gcsaliases); err != nil {
 			return fmt.Errorf("failed to publish to gcs: %v", err)
+		}
+	}
+	if flags.helmbucket != "" {
+		if err := Helm(manifest, flags.helmbucket); err != nil {
+			return fmt.Errorf("failed to publish to helm charts: %v", err)
 		}
 	}
 	if flags.github != "" {

--- a/pkg/publish/helm.go
+++ b/pkg/publish/helm.go
@@ -1,0 +1,114 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publish
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"cloud.google.com/go/storage"
+
+	"istio.io/pkg/log"
+	"istio.io/release-builder/pkg/model"
+	"istio.io/release-builder/pkg/util"
+)
+
+// Helm publishes charts to the given GCS bucket
+func Helm(manifest model.Manifest, bucket string) error {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+		return err
+	}
+
+	// Allow the caller to pass a reference like bucket/folder/subfolder, but split this to
+	// bucket, and folder/subfolder prefix
+	splitbucket := strings.SplitN(bucket, "/", 2)
+	bucketName := splitbucket[0]
+	objectPrefix := ""
+	if len(splitbucket) > 1 {
+		objectPrefix = splitbucket[1]
+	}
+	bkt := client.Bucket(bucketName)
+
+	helmDir := filepath.Join(manifest.Directory, "helm")
+
+	// First pull down the current index, so we can merge it. This has a race, but we are extremely unlikely
+	// to publish two versions in the same second
+	if err := fetchCurrentIndex(helmDir, bkt, objectPrefix); err != nil {
+		return fmt.Errorf("fetch index: %v", err)
+	}
+
+	// Create a new index, merging the existing one with our new charts
+	idxCmd := util.VerboseCommand("helm", "repo", "index", ".",
+		"--url", fmt.Sprintf("https://%s.storage.googleapis.com/%s", bucketName, objectPrefix),
+		"--merge", "index.yaml")
+	idxCmd.Dir = helmDir
+	if err := idxCmd.Run(); err != nil {
+		return fmt.Errorf("index repo: %v", err)
+	}
+	dirInfo, err := ioutil.ReadDir(helmDir)
+	if err != nil {
+		return err
+	}
+	for _, f := range dirInfo {
+		objName := path.Join(objectPrefix, f.Name())
+		obj := bkt.Object(objName)
+		w := obj.NewWriter(ctx)
+		f, err := os.Open(filepath.Join(helmDir, f.Name()))
+		if err != nil {
+			return fmt.Errorf("failed to open %v: %v", f.Name(), err)
+		}
+		r := bufio.NewReader(f)
+		if _, err := io.Copy(w, r); err != nil {
+			return fmt.Errorf("failed writing %v: %v", f.Name(), err)
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("failed to close bucket: %v", err)
+		}
+		log.Infof("Wrote %v to gs://%s/%s", f.Name(), bucketName, objName)
+	}
+
+	return nil
+}
+
+func fetchCurrentIndex(outDir string, bkt *storage.BucketHandle, objectPrefix string) error {
+	r, err := bkt.Object(filepath.Join(objectPrefix, "index.yaml")).NewReader(context.Background())
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			// This may be fine if we are publishing for the first time. Helm will allow us to `--merge non-existing-file.yaml`.
+			log.Warnf("existing index.yaml does not exist")
+			return nil
+		}
+		return err
+	}
+	defer r.Close()
+	idx, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(outDir, "index.yaml"), idx, 0o644); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -289,6 +289,10 @@ func TestHelmChartVersions(r ReleaseInfo) error {
 		if err := c.Run(); err != nil {
 			return err
 		}
+		if chart == "gateway" || chart == "base" {
+			// Gateway has no hub/tag
+			continue
+		}
 		if err := validateHubTag(r, buf.Bytes(), "global"); err != nil {
 			return fmt.Errorf("%s: %v", chart, err)
 		}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -276,11 +276,10 @@ func TestProxyVersion(r ReleaseInfo) error {
 
 func TestHelmChartVersions(r ReleaseInfo) error {
 	expected := []string{
-		"config",
-		"istio-cni",
-		"istio-discovery",
-		"istio-egress",
-		"istio-ingress",
+		"cni",
+		"istiod",
+		"base",
+		"gateway",
 	}
 	for _, chart := range expected {
 		buf := bytes.Buffer{}

--- a/release/build.sh
+++ b/release/build.sh
@@ -29,6 +29,7 @@ gcloud auth configure-docker -q
 
 PRERELEASE_DOCKER_HUB=${PRERELEASE_DOCKER_HUB:-gcr.io/istio-prerelease-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-prerelease/prerelease}
+HELM_BUCKET=${HELM_BUCKET:-istio-prerelease/charts}
 
 if [[ -n ${ISTIO_ENVOY_BASE_URL:-} ]]; then
   PROXY_OVERRIDE="proxyOverride: ${ISTIO_ENVOY_BASE_URL}"
@@ -100,4 +101,4 @@ export PATH=${GOPATH}/bin:${PATH}
 
 go run main.go build --manifest <(echo "${MANIFEST}") --githubtoken "${GITHUB_TOKEN_FILE}"
 go run main.go validate --release "${WORK_DIR}/out"
-go run main.go publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --dockerhub "${PRERELEASE_DOCKER_HUB}" --dockertags "${VERSION}"
+go run main.go publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --helmbucket "${HELM_BUCKET}" --dockerhub "${PRERELEASE_DOCKER_HUB}" --dockertags "${VERSION}"

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -31,6 +31,7 @@ VERSION="$(cat "${WD}/trigger-publish")"
 
 SOURCE_GCS_BUCKET=${SOURCE_GCS_BUCKET:-istio-prerelease/prerelease}
 GCS_BUCKET=${GCS_BUCKET:-istio-release/releases}
+HELM_BUCKET=${HELM_BUCKET:-istio-release/charts}
 DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
 GITHUB_ORG=${GITHUB_ORG:-istio}
 GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE:-}
@@ -45,6 +46,7 @@ export PATH=${GOPATH}/bin:${PATH}
 gsutil -m cp -r "gs://${SOURCE_GCS_BUCKET}/${VERSION}/*" "${WORK_DIR}"
 go run main.go publish --release "${WORK_DIR}" \
     --gcsbucket "${GCS_BUCKET}" \
+    --helmbucket "${HELM_BUCKET}" \
     --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}" \
     --github "${GITHUB_ORG}" --githubtoken "${GITHUB_TOKEN_FILE}" \
     --grafanatoken "${GRAFANA_TOKEN_FILE}"

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -29,6 +29,7 @@ fi
 
 DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/test}
+HELM_BUCKET=${HELM_BUCKET:-istio-build/test/charts}
 VERSION="1.12.0-releasebuilder.$(git rev-parse --short HEAD)"
 
 WORK_DIR="$(mktemp -d)/build"
@@ -86,5 +87,5 @@ go run main.go build --manifest <(echo "${MANIFEST}")
 go run main.go validate --release "${WORK_DIR}/out"
 
 if [[ -z "${DRY_RUN:-}" ]]; then
-  go run main.go publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}"
+  go run main.go publish --release "${WORK_DIR}/out" --helmbucket "${HELM_BUCKET}" --gcsbucket "${GCS_BUCKET}" --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}"
 fi


### PR DESCRIPTION
This adds building and publishing of helm charts to a proper helm repo.
On build, we run `helm package` on each chart, giving us a bunch of tgz
files. We push these to GCS.

On publish, we pull down the existing index.yaml. We then run `helm repo
ndex --merge index.yaml`. This adds our new tgz charts. Finally, we push
up the new charts, as well as the new index.yaml (overwriting existing
index.yaml).

Users can then run `helm repo add istio https://istio-release.storage.googleapis.com/charts`
and then later do things like `helm install istio/base`.

Next steps:
* Backfill some older versions.
* Update istio.io docs to use this instead of local files
* Write a blog post?
* Publish to artifact hub. I am pretty sure this requires no
release-builder changes, its just a UI for a helm repo.