### PR TITLE
Switch github token used during build for image update PR

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -37,7 +37,11 @@ fi
 # We shouldn't push here right now, this is just which version to embed in the Helm charts
 DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
 
-GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE:-}
+# For build, don't use GITHUB_TOKEN_FILE env var set by preset-release-pipeline
+# which is pointing to the github token for istio-release-robot. Instead point to
+# the github token for istio-testing. The token is currently only used to create the
+# PR to update the build image.
+GITHUB_TOKEN_FILE=/etc/github-token/oauth
 
 VERSION="$(cat "${WD}/trigger-build")"
 


### PR DESCRIPTION
It was noted in PRs like https://github.com/istio/istio/pull/34791 that the build automation creating the PR uses `istio-release-robot` instead of `istio-testing`.

Looking into why this occurs, the `release/build.sh` used GITHUB_TOKEN_FILE to get the token for the commits and PR creation. The test-infra job has the release requirement set: https://github.com/istio/test-infra/blob/master/prow/config/jobs/release-builder.yaml#L38 which vis https://github.com/istio/test-infra/blob/master/prow/config/jobs/.global.yaml#L92-L94 sets the preset-release-pipeline label.  

https://github.com/istio/test-infra/blob/master/prow/cluster/jobs/all-presets.yaml#L40-L45 causes GITHUB_TOKEN_FILE to point to the mounted token for `istio-release-robot`.

I didn't want to do anything with the `release` requirement since a number of other items are used by the build. However, the GitHub token is only used for the commit and PR creation during build, so it made sense to update the script to use the `istio-testing` token with is loaded by the `github` requirement. It may also make sense to change the test-infra requirement from `github-optional`to `github` in the proxy job.


A pointer to a prow job for info: https://prow.istio.io/view/gs/istio-prow/logs/build-release_release-builder_release-1.11_postsubmit/1432849405869821952

