### PR TITLE
Add cosign image signing support to release-builder

### DIFF
--- a/pkg/publish/cmd.go
+++ b/pkg/publish/cmd.go
@@ -40,6 +40,7 @@ var (
 		github       string
 		githubtoken  string
 		grafanatoken string
+		cosignkey    string
 	}{}
 	publishCmd = &cobra.Command{
 		Use:          "publish",
@@ -84,6 +85,8 @@ func init() {
 		"The file containing a github token.")
 	publishCmd.PersistentFlags().StringVar(&flags.grafanatoken, "grafanatoken", flags.grafanatoken,
 		"The file containing a grafana.com API token.")
+	publishCmd.PersistentFlags().StringVar(&flags.cosignkey, "cosignkey", flags.cosignkey,
+		"A key for signing images, as passed to cosign using 'cosign sign -key <x>'")
 }
 
 func GetPublishCommand() *cobra.Command {
@@ -99,7 +102,7 @@ func validateFlags() error {
 
 func Publish(manifest model.Manifest) error {
 	if flags.dockerhub != "" {
-		if err := Docker(manifest, flags.dockerhub, flags.dockertags); err != nil {
+		if err := Docker(manifest, flags.dockerhub, flags.dockertags, flags.cosignkey); err != nil {
 			return fmt.Errorf("failed to publish to docker: %v", err)
 		}
 	}

--- a/pkg/publish/docker.go
+++ b/pkg/publish/docker.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg/model"
 	"istio.io/release-builder/pkg/util"
 )
@@ -36,7 +37,9 @@ func Docker(manifest model.Manifest, hub string, tags []string, cosignkey string
 	// able to run 'cosign public-key <key>'.
 	cosignEnabled := false
 	if cosignkey != "" {
-		if err := util.VerboseCommand("cosign", "public-key", "-key", cosignkey).Run(); err == nil {
+		if err := util.VerboseCommand("cosign", "public-key", "-key", cosignkey).Run(); err != nil {
+			log.Errorf("Argument '--cosignkey' nonempty but unable to access key %v, disabling signing.", err)
+		} else {
 			cosignEnabled = true
 		}
 	}

--- a/release/build.sh
+++ b/release/build.sh
@@ -36,10 +36,6 @@ if [[ -n ${ISTIO_ENVOY_BASE_URL:-} ]]; then
   PROXY_OVERRIDE="proxyOverride: ${ISTIO_ENVOY_BASE_URL}"
 fi
 
-if [[ -z "${COSIGN_KEY}" ]]; then
-  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
-fi
-
 # We shouldn't push here right now, this is just which version to embed in the Helm charts
 DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
 
@@ -111,7 +107,7 @@ go run main.go build \
 go run main.go validate --release "${WORK_DIR}/out"
 
 go run main.go publish --release "${WORK_DIR}/out" \
-  ${COSIGN_ARGS:-} \
+  --cosignkey "${COSIGN_KEY:-}" \
   --gcsbucket "${GCS_BUCKET}" \
   --helmbucket "${HELM_BUCKET}" \
   --dockerhub "${PRERELEASE_DOCKER_HUB}" \

--- a/release/build.sh
+++ b/release/build.sh
@@ -30,9 +30,14 @@ gcloud auth configure-docker -q
 PRERELEASE_DOCKER_HUB=${PRERELEASE_DOCKER_HUB:-gcr.io/istio-prerelease-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-prerelease/prerelease}
 HELM_BUCKET=${HELM_BUCKET:-istio-prerelease/charts}
+COSIGN_KEY=${COSIGN_KEY:-}
 
 if [[ -n ${ISTIO_ENVOY_BASE_URL:-} ]]; then
   PROXY_OVERRIDE="proxyOverride: ${ISTIO_ENVOY_BASE_URL}"
+fi
+
+if [[ -z "${COSIGN_KEY}" ]]; then
+  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
 fi
 
 # We shouldn't push here right now, this is just which version to embed in the Helm charts
@@ -99,6 +104,15 @@ EOF
 # "Temporary" hacks
 export PATH=${GOPATH}/bin:${PATH}
 
-go run main.go build --manifest <(echo "${MANIFEST}") --githubtoken "${GITHUB_TOKEN_FILE}"
+go run main.go build \
+  --manifest <(echo "${MANIFEST}") \
+  --githubtoken "${GITHUB_TOKEN_FILE}"
+
 go run main.go validate --release "${WORK_DIR}/out"
-go run main.go publish --release "${WORK_DIR}/out" --gcsbucket "${GCS_BUCKET}" --helmbucket "${HELM_BUCKET}" --dockerhub "${PRERELEASE_DOCKER_HUB}" --dockertags "${VERSION}"
+
+go run main.go publish --release "${WORK_DIR}/out" \
+  ${COSIGN_ARGS:-} \
+  --gcsbucket "${GCS_BUCKET}" \
+  --helmbucket "${HELM_BUCKET}" \
+  --dockerhub "${PRERELEASE_DOCKER_HUB}" \
+  --dockertags "${VERSION}"

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -36,6 +36,7 @@ DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
 GITHUB_ORG=${GITHUB_ORG:-istio}
 GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE:-}
 GRAFANA_TOKEN_FILE=${GRAFANA_TOKEN_FILE:-}
+COSIGN_KEY=${COSIGN_KEY:-}
 
 WORK_DIR="$(mktemp -d)/release"
 mkdir -p "${WORK_DIR}"
@@ -51,8 +52,13 @@ go run main.go publish --release "${WORK_DIR}" \
     --github "${GITHUB_ORG}" --githubtoken "${GITHUB_TOKEN_FILE}" \
     --grafanatoken "${GRAFANA_TOKEN_FILE}"
 
+if [[ -z "${COSIGN_KEY}" ]]; then
+  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
+fi
+
 # Also push images to a GCR repo, in case of dockerhub rate limiting issues for
 # large clusters (see https://docs.docker.com/docker-hub/download-rate-limit/).
 go run main.go publish --release "${WORK_DIR}" \
+    "${COSIGN_ARGS:-}" \
     --dockerhub "gcr.io/istio-release" \
     --dockertags "${VERSION}"

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -38,10 +38,6 @@ GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE:-}
 GRAFANA_TOKEN_FILE=${GRAFANA_TOKEN_FILE:-}
 COSIGN_KEY=${COSIGN_KEY:-}
 
-if [[ -z "${COSIGN_KEY}" ]]; then
-  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
-fi
-
 WORK_DIR="$(mktemp -d)/release"
 mkdir -p "${WORK_DIR}"
 
@@ -50,7 +46,7 @@ export PATH=${GOPATH}/bin:${PATH}
 
 gsutil -m cp -r "gs://${SOURCE_GCS_BUCKET}/${VERSION}/*" "${WORK_DIR}"
 go run main.go publish --release "${WORK_DIR}" \
-    ${COSIGN_ARGS:-} \
+    --cosignkey "${COSIGN_KEY:-}" \
     --gcsbucket "${GCS_BUCKET}" \
     --helmbucket "${HELM_BUCKET}" \
     --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}" \
@@ -60,6 +56,6 @@ go run main.go publish --release "${WORK_DIR}" \
 # Also push images to a GCR repo, in case of dockerhub rate limiting issues for
 # large clusters (see https://docs.docker.com/docker-hub/download-rate-limit/).
 go run main.go publish --release "${WORK_DIR}" \
-    ${COSIGN_ARGS:-} \
+    --cosignkey "${COSIGN_KEY:-}" \
     --dockerhub "gcr.io/istio-release" \
     --dockertags "${VERSION}"

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -31,6 +31,7 @@ DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/test}
 HELM_BUCKET=${HELM_BUCKET:-istio-build/test/charts}
 VERSION="1.12.0-releasebuilder.$(git rev-parse --short HEAD)"
+COSIGN_KEY=${COSIGN_KEY:-}
 
 WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"
@@ -86,6 +87,16 @@ go run main.go build --manifest <(echo "${MANIFEST}")
 
 go run main.go validate --release "${WORK_DIR}/out"
 
+if [[ -z "${COSIGN_KEY}" ]]; then
+  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
+fi
+
 if [[ -z "${DRY_RUN:-}" ]]; then
-  go run main.go publish --release "${WORK_DIR}/out" --helmbucket "${HELM_BUCKET}" --gcsbucket "${GCS_BUCKET}" --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}"
+go run main.go publish --release "${WORK_DIR}/out" \
+  "${COSIGN_ARGS:-}" \
+  --helmbucket "${HELM_BUCKET}" \
+  --gcsbucket "${GCS_BUCKET}" \
+  --dockerhub "${DOCKER_HUB}" \
+  --dockertags "${VERSION}"
+
 fi

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -33,10 +33,6 @@ HELM_BUCKET=${HELM_BUCKET:-istio-build/test/charts}
 VERSION="1.12.0-releasebuilder.$(git rev-parse --short HEAD)"
 COSIGN_KEY=${COSIGN_KEY:-}
 
-if [[ -z "${COSIGN_KEY}" ]]; then
-  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
-fi
-
 WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"
 
@@ -93,7 +89,7 @@ go run main.go validate --release "${WORK_DIR}/out"
 
 if [[ -z "${DRY_RUN:-}" ]]; then
 go run main.go publish --release "${WORK_DIR}/out" \
-  ${COSIGN_ARGS:-} \
+  --cosignkey "${COSIGN_KEY:-}" \
   --helmbucket "${HELM_BUCKET}" \
   --gcsbucket "${GCS_BUCKET}" \
   --dockerhub "${DOCKER_HUB}" \

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -33,6 +33,10 @@ HELM_BUCKET=${HELM_BUCKET:-istio-build/test/charts}
 VERSION="1.12.0-releasebuilder.$(git rev-parse --short HEAD)"
 COSIGN_KEY=${COSIGN_KEY:-}
 
+if [[ -z "${COSIGN_KEY}" ]]; then
+  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
+fi
+
 WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"
 
@@ -87,13 +91,9 @@ go run main.go build --manifest <(echo "${MANIFEST}")
 
 go run main.go validate --release "${WORK_DIR}/out"
 
-if [[ -z "${COSIGN_KEY}" ]]; then
-  COSIGN_ARGS="--cosignkey ${COSIGN_KEY}"
-fi
-
 if [[ -z "${DRY_RUN:-}" ]]; then
 go run main.go publish --release "${WORK_DIR}/out" \
-  "${COSIGN_ARGS:-}" \
+  ${COSIGN_ARGS:-} \
   --helmbucket "${HELM_BUCKET}" \
   --gcsbucket "${GCS_BUCKET}" \
   --dockerhub "${DOCKER_HUB}" \


### PR DESCRIPTION
Adds support for signing images to the release-builder workflow. Depends on deployment of https://github.com/istio/test-infra/pull/3573