### PR TITLE
Skip helm charts for CI builds

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -38,10 +38,10 @@ func Build(manifest model.Manifest, githubToken string) error {
 		}
 	}
 
+	if err := SanitizeAllCharts(manifest); err != nil {
+		return fmt.Errorf("failed to sanitize charts: %v", err)
+	}
 	if vm, _ := regexp.Match(`\d+\.\d+\.\d+`, []byte(manifest.Version)); vm {
-		if err := SanitizeAllCharts(manifest); err != nil {
-			return fmt.Errorf("failed to sanitize charts: %v", err)
-		}
 		if _, f := manifest.BuildOutputs[model.Helm]; f {
 			if err := HelmCharts(manifest); err != nil {
 				return fmt.Errorf("failed to build HelmCharts: %v", err)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 
 	"sigs.k8s.io/yaml"
 
@@ -37,13 +38,17 @@ func Build(manifest model.Manifest, githubToken string) error {
 		}
 	}
 
-	if err := SanitizeAllCharts(manifest); err != nil {
-		return fmt.Errorf("failed to sanitize charts: %v", err)
-	}
-	if _, f := manifest.BuildOutputs[model.Helm]; f {
-		if err := HelmCharts(manifest); err != nil {
-			return fmt.Errorf("failed to build HelmCharts: %v", err)
+	if vm, _ := regexp.Match(`\d+\.\d+\.\d+`, []byte(manifest.Version)); vm {
+		if err := SanitizeAllCharts(manifest); err != nil {
+			return fmt.Errorf("failed to sanitize charts: %v", err)
 		}
+		if _, f := manifest.BuildOutputs[model.Helm]; f {
+			if err := HelmCharts(manifest); err != nil {
+				return fmt.Errorf("failed to build HelmCharts: %v", err)
+			}
+		}
+	} else {
+		log.Warnf("Invalid Semantic Version. Skipping Charts build")
 	}
 
 	if _, f := manifest.BuildOutputs[model.Debian]; f {


### PR DESCRIPTION
In CI jobs helm chart version semantics differ from what is used for releases and that causes failures in a build flow. Hence skipping helm charts for non release builds