### PR TITLE
Add separate flag for building base images

### DIFF
--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -11,9 +11,6 @@ docker: docker.io/istio
 # Directory specifies the working directory to build in
 directory: /tmp/istio-release
 
-# Ignore/Continue after a base image vulnerability is found
-ignoreVulnerability: true
-
 # Dependencies specifies dependencies of the build
 # Note - only istio
 # Other dependencies are only required to grab licenses and publish tags to Github.

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -73,14 +73,10 @@ var (
 			}
 
 			if flags.buildBaseImages {
-					if err := Scanner(manifest, token, savedIstioGit, savedIstioBranch); err != nil {
-						if manifest.IgnoreVulnerability {
-							log.Infof("Ignoring vulnerability scanning error: %v", err)
-						} else {
-							return fmt.Errorf("failed image scan: %v", err)
-						}
-					}
-					return nil
+				if err := Scanner(manifest, token, savedIstioGit, savedIstioBranch); err != nil {
+					return fmt.Errorf("failed image scan: %v", err)
+				}
+				return nil
 			}
 
 			if err := Build(manifest, token); err != nil {

--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -70,11 +70,6 @@ func Scanner(manifest model.Manifest, githubToken, git, branch string) error {
 		return fmt.Errorf("base image scan of %s failed. Unable to process exit code:\n %s", baseImageName, err.Error())
 	}
 
-	// Failed with an error indicating vulnerabilities were found. If IgnoreVulernability is true, just just return
-	//if manifest.IgnoreVulnerability {
-	//	return nil
-	//}
-
 	// Else build a new set of images.
 	buildTimestamp := strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", "-")
 	log.Infof("new base tag: %s", buildTimestamp)

--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -71,7 +71,10 @@ func Scanner(manifest model.Manifest, githubToken, git, branch string) error {
 	}
 
 	// Else build a new set of images.
-	buildTimestamp := strings.ReplaceAll(time.Now().Format(time.RFC3339), ":", "-")
+	// Time format chosen for consistency with build tools tag:
+	// https://github.com/istio/tools/blob/ee7da00900dc878a2e865e43250c34735f130b7a/docker/build-tools/build-and-push.sh#L27
+	const timeFormat = "2006-01-02T15-04-05"
+	buildTimestamp := time.Now().Format(timeFormat)
 	log.Infof("new base tag: %s", buildTimestamp)
 
 	// Setup for multiarch build.

--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -71,7 +71,6 @@ func InputManifestToManifest(in model.InputManifest) (model.Manifest, error) {
 		BuildOutputs:        outputs,
 		ProxyOverride:       in.ProxyOverride,
 		GrafanaDashboards:   in.GrafanaDashboards,
-		IgnoreVulnerability: in.IgnoreVulnerability,
 	}, nil
 }
 

--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -64,13 +64,13 @@ func InputManifestToManifest(in model.InputManifest) (model.Manifest, error) {
 		outputs[model.Scanner] = struct{}{}
 	}
 	return model.Manifest{
-		Dependencies:        in.Dependencies,
-		Version:             in.Version,
-		Docker:              in.Docker,
-		Directory:           wd,
-		BuildOutputs:        outputs,
-		ProxyOverride:       in.ProxyOverride,
-		GrafanaDashboards:   in.GrafanaDashboards,
+		Dependencies:      in.Dependencies,
+		Version:           in.Version,
+		Docker:            in.Docker,
+		Directory:         wd,
+		BuildOutputs:      outputs,
+		ProxyOverride:     in.ProxyOverride,
+		GrafanaDashboards: in.GrafanaDashboards,
 	}, nil
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -136,8 +136,6 @@ type InputManifest struct {
 	BuildOutputs []string `json:"outputs"`
 	// GrafanaDashboards defines a mapping of dashboard name -> ID of the dashboard on grafana.com
 	GrafanaDashboards map[string]int `json:"dashboards"`
-	// Ignore/Continue after a base image vulnerability is found.
-	IgnoreVulnerability bool `json:"ignoreVulnerability"`
 }
 
 // Manifest defines what is in a release
@@ -159,8 +157,6 @@ type Manifest struct {
 	// GrafanaDashboards defines a mapping of dashboard name -> ID of the dashboard on grafana.com
 	// Note: this tool is not yet smart enough to create dashboards that do not already exist, it can only update dashboards.
 	GrafanaDashboards map[string]int `json:"dashboards"`
-	// Ignore/Continue after a base image vulnerability is found.
-	IgnoreVulnerability bool `json:"ignoreVulnerability"`
 }
 
 // RepoDir is a helper to return the working directory for a repo

--- a/release/build.sh
+++ b/release/build.sh
@@ -71,8 +71,8 @@ export PATH=${GOPATH}/bin:${PATH}
 
 if [ $BUILD_BASE_IMAGES = true ] ; then
   MANIFEST=$(cat <<EOF
-version: "1.8.0-test"
-docker: "docker.io/istio"
+version: "${VERSION}"
+docker: "${DOCKER_HUB}"
 directory: "${WORK_DIR}"
 dependencies:
   istio:

--- a/release/build.sh
+++ b/release/build.sh
@@ -17,7 +17,41 @@
 WD=$(dirname "$0")
 WD=$(cd "$WD"; pwd)
 
-set -x
+set -eux
+
+gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+# Temporary hack to get around some gcloud credential issues
+mkdir ~/.docker
+cp "${DOCKER_CONFIG}/config.json" ~/.docker/
+export DOCKER_CONFIG=~/.docker
+gcloud auth configure-docker -q
+
+PRERELEASE_DOCKER_HUB=${PRERELEASE_DOCKER_HUB:-gcr.io/istio-prerelease-testing}
+GCS_BUCKET=${GCS_BUCKET:-istio-prerelease/prerelease}
+HELM_BUCKET=${HELM_BUCKET:-istio-prerelease/charts}
+COSIGN_KEY=${COSIGN_KEY:-}
+
+if [[ -n ${ISTIO_ENVOY_BASE_URL:-} ]]; then
+  PROXY_OVERRIDE="proxyOverride: ${ISTIO_ENVOY_BASE_URL}"
+fi
+
+# We shouldn't push here right now, this is just which version to embed in the Helm charts
+DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
+
+# When set, we skip the actual build, scan base images, and create and push new ones if needed.
+BUILD_BASE_IMAGES=${BUILD_BASE_IMAGES:=false}
+
+# For build, don't use GITHUB_TOKEN_FILE env var set by preset-release-pipeline
+# which is pointing to the github token for istio-release-robot. Instead point to
+# the github token for istio-testing. The token is currently only used to create the
+# PR to update the build image.
+GITHUB_TOKEN_FILE=/etc/github-token/oauth
+
+VERSION="$(cat "${WD}/trigger-build")"
+
+WORK_DIR="$(mktemp -d)/build"
+mkdir -p "${WORK_DIR}"
 
 MANIFEST=$(cat <<EOF
 version: "${VERSION}"

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -40,7 +40,6 @@ MANIFEST=$(cat <<EOF
 version: ${VERSION}
 docker: ${DOCKER_HUB}
 directory: ${WORK_DIR}
-ignoreVulnerability: true
 dependencies:
   istio:
     git: https://github.com/istio/istio


### PR DESCRIPTION
Adds the `--build-base-images` flag to the build subcommand, when set we will not run the entire build and instead just scan base images and build new ones if needed.

Also adds steps for multiarch to the base building automation, uses a timestamp instead of an incrementing version number for the tag, and removes the `IgnoreVulnerabilities` flag since it doesn't make sense to have as a separate option when it's its own build step.

In preparation to add a daily job that runs `BUILD_BASE_IMAGES=true ./release/build.sh`.