### PR TITLE
Set default revision tag to default for fresh installs

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -140,7 +140,7 @@ func sanitizeChart(manifest model.Manifest, s string) error {
 				contents = strings.ReplaceAll(contents, before, after)
 			}
 
-			if filepath.Base(s) == path.Join(manifest.RepoDir("istio"), baseChart) && fname == "values.yaml" {
+			if s == path.Join(manifest.RepoDir("istio"), baseChart) && fname == "values.yaml" {
 				before := `defaultRevision: ""`
 				after := "defaultRevision: default"
 				contents = strings.ReplaceAll(contents, before, after)


### PR DESCRIPTION
Fixes Item 1 in https://github.com/istio/istio/issues/35690

This will NOT change anything for istioctl based installs, but will only change helm charts before they are published. This will allow the users to not have to set `--set defaultRevision=default` on fresh installs.