### PR TITLE
Return error from cmd.Run when running command with output

### DIFF
--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -53,8 +53,7 @@ func RunWithOutput(name string, arg ...string) (string, error) {
 	cmd.Stdout = io.MultiWriter(os.Stdout, &outBuffer)
 	cmd.Stderr = io.MultiWriter(os.Stderr, &errBuffer)
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("running command %s failed: %s: %s",
-			strings.Join(arg, " "), err.Error(), errBuffer.String())
+		return "", err
 	}
 	return outBuffer.String(), nil
 }


### PR DESCRIPTION
Makes it so that we can parse the error as `exec.ExitError` and read the exit code from it