### PR TITLE
Add back info output for failure since it's no longer part of the returned err

### DIFF
--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -53,6 +53,8 @@ func RunWithOutput(name string, arg ...string) (string, error) {
 	cmd.Stdout = io.MultiWriter(os.Stdout, &outBuffer)
 	cmd.Stderr = io.MultiWriter(os.Stderr, &errBuffer)
 	if err := cmd.Run(); err != nil {
+		log.Infof("Running command %s %s failed: %s: %s",
+			name, strings.Join(arg, " "), err.Error(), errBuffer.String())
 		return "", err
 	}
 	return outBuffer.String(), nil


### PR DESCRIPTION
This was removed in https://github.com/istio/release-builder/pull/885.