### PR TITLE
Allow specifying a VERSION override

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -48,7 +48,7 @@ BUILD_BASE_IMAGES=${BUILD_BASE_IMAGES:=false}
 # PR to update the build image.
 GITHUB_TOKEN_FILE=/etc/github-token/oauth
 
-VERSION="$(cat "${WD}/trigger-build")"
+VERSION=${VERSION:-$(cat "${WD}/trigger-build")}
 
 WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"


### PR DESCRIPTION
The allows one to specify a VERSION to be used instead of the value from the /release/build-trigger file.

The use case for this is when the automated jobs are building new images. The new image name is found by adding the"-" and the date to the specified VERSION.  The prow jobs for the automated job (PR coming soon) would then specify the VERSION to be used if images are created.