### PR TITLE
Generate SBOM for istio repository

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -89,7 +89,7 @@ func Build(manifest model.Manifest, githubToken string) error {
 		return fmt.Errorf("failed to package license file: %v", err)
 	}
 
-	if err := Sbom(manifest); err != nil {
+	if err := GenerateBillOfMaterials(manifest); err != nil {
 		return fmt.Errorf("failed to generate sbom: %v", err)
 	}
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -89,6 +89,10 @@ func Build(manifest model.Manifest, githubToken string) error {
 		return fmt.Errorf("failed to package license file: %v", err)
 	}
 
+	if err := Sbom(manifest); err != nil {
+		return fmt.Errorf("failed to generate sbom: %v", err)
+	}
+
 	return nil
 }
 

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -1,0 +1,39 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+
+	"istio.io/pkg/log"
+	"istio.io/release-builder/pkg/model"
+	"istio.io/release-builder/pkg/util"
+)
+
+// Sbom generates Software Bill Of Materials for istio repo in an SPDX readable format.
+func Sbom(manifest model.Manifest) error {
+	// Retrieve istio repository path to run the sbom generator
+	istioRepoDir := manifest.RepoDir("istio")
+	outDir := manifest.OutDir()
+
+	// Run spdx sbom generator to generate the software bill of materials(SBOM) for istio
+	log.Infof("Running spdx sbom generator for istio repository")
+	if err := util.VerboseCommand("docker",
+		"run", "--rm", "-v", istioRepoDir+":/repository", "-v", outDir+":/out", "spdx/spdx-sbom-generator", "--include-license-text",
+		"--output-dir", "/out", "--path", "/repository").Run(); err != nil {
+		return fmt.Errorf("couldn't generate sbom for istio: %v", err)
+	}
+	return nil
+}

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -52,15 +52,16 @@ func GenerateBillOfMaterials(manifest model.Manifest) error {
 
 	// Run bom generator to generate the software bill of materials(SBOM) for istio.
 	log.Infof("Generating Software Bill of Materials for istio release artifacts")
-	if err := util.VerboseCommand("bom", "generate", "--namespace", releaseSbomNamespace,
-		"--ignore", "licenses,'*.sha256',docker", "--dirs", manifest.OutDir(),
+	if err := util.VerboseCommand("bom", "generate", "--name", "Istio Release "+manifest.Version,
+		"--namespace", releaseSbomNamespace, "--ignore", "licenses,'*.sha256',docker", "--dirs", manifest.OutDir(),
 		"--image-archive", strings.Join(dockerImages, ","), "--output", releaseSbomFile).Run(); err != nil {
 		return fmt.Errorf("couldn't generate sbom for istio release artifacts: %v", err)
 	}
 
 	// Run bom generator to generate the software bill of materials(SBOM) for istio.
 	log.Infof("Generating Software Bill of Materials for istio source code")
-	if err := util.VerboseCommand("bom", "generate", "--namespace", sourceSbomNamespace, "-d", istioRepoDir, "--output", sourceSbomFile).Run(); err != nil {
+	if err := util.VerboseCommand("bom", "generate", "--name", "Istio Source "+manifest.Version,
+		"--namespace", sourceSbomNamespace, "-d", istioRepoDir, "--output", sourceSbomFile).Run(); err != nil {
 		return fmt.Errorf("couldn't generate sbom for istio source: %v", err)
 	}
 	return nil

--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -39,12 +39,12 @@ func GenerateBillOfMaterials(manifest model.Manifest) error {
 
 	// construct all the docker image tarball names as bom currently cannot accept directory as input
 	dockerDir := path.Join(manifest.OutDir(), "docker")
-	docker_images := []string{}
+	dockerImages := []string{}
 	if err := filepath.Walk(dockerDir, func(path string, fi os.FileInfo, err error) error {
 		if fi.IsDir() {
 			return nil
 		}
-		docker_images = append(docker_images, path)
+		dockerImages = append(dockerImages, path)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to walk directory %s: %v", dockerDir, err)
@@ -54,7 +54,7 @@ func GenerateBillOfMaterials(manifest model.Manifest) error {
 	log.Infof("Generating Software Bill of Materials for istio release artifacts")
 	if err := util.VerboseCommand("bom", "generate", "--namespace", releaseSbomNamespace,
 		"--ignore", "licenses,'*.sha256',docker", "--dirs", manifest.OutDir(),
-		"--image-archive", strings.Join(docker_images, ","), "--output", releaseSbomFile).Run(); err != nil {
+		"--image-archive", strings.Join(dockerImages, ","), "--output", releaseSbomFile).Run(); err != nil {
 		return fmt.Errorf("couldn't generate sbom for istio release artifacts: %v", err)
 	}
 


### PR DESCRIPTION
Attempt to generate SBOM for istio repository in  SPDX format.
This PR integrates the Bill of Materials code Into the istio release process. The current PR generates the first SBOM file that only describes the istio source code. The complete plan is to generate one SBOM for the source code and one for the release artifacts. 

kbs/bom utility is in the process of publishing a new release soon, which will have enhanced functionalities that would help us generate BOM for docker image-archives, and other tarballs in the release. Waiting for that to add the remaining BOM generation portion for release artifacts. 

RFC : [SBOM for Istio](https://docs.google.com/document/d/10ITZUUf-aGbeiBKfr-EqrQTPfPpVQmUT/)

Signed-off-by: Faseela K <faseela.k@est.tech>