### PR TITLE
Make bom log-level to error

### DIFF
--- a/pkg/build/sbom.go
+++ b/pkg/build/sbom.go
@@ -52,7 +52,7 @@ func GenerateBillOfMaterials(manifest model.Manifest) error {
 
 	// Run bom generator to generate the software bill of materials(SBOM) for istio.
 	log.Infof("Generating Software Bill of Materials for istio release artifacts")
-	if err := util.VerboseCommand("bom", "generate", "--name", "Istio Release "+manifest.Version,
+	if err := util.VerboseCommand("bom", "--log-level", "error", "generate", "--name", "Istio Release "+manifest.Version,
 		"--namespace", releaseSbomNamespace, "--ignore", "licenses,'*.sha256',docker", "--dirs", manifest.OutDir(),
 		"--image-archive", strings.Join(dockerImages, ","), "--output", releaseSbomFile).Run(); err != nil {
 		return fmt.Errorf("couldn't generate sbom for istio release artifacts: %v", err)
@@ -60,8 +60,8 @@ func GenerateBillOfMaterials(manifest model.Manifest) error {
 
 	// Run bom generator to generate the software bill of materials(SBOM) for istio.
 	log.Infof("Generating Software Bill of Materials for istio source code")
-	if err := util.VerboseCommand("bom", "generate", "--name", "Istio Source "+manifest.Version,
-		"--namespace", sourceSbomNamespace, "-d", istioRepoDir, "--output", sourceSbomFile).Run(); err != nil {
+	if err := util.VerboseCommand("bom", "--log-level", "error", "generate", "--name", "Istio Source "+manifest.Version,
+		"--namespace", sourceSbomNamespace, "--dirs", istioRepoDir, "--output", sourceSbomFile).Run(); err != nil {
 		return fmt.Errorf("couldn't generate sbom for istio source: %v", err)
 	}
 	return nil


### PR DESCRIPTION
Currently `bom generate` logs by default at info level and
adds a lot of info logs which are not really important for our debugging.
release_builder dry run logs are already too huge, so do not want to unnecessarily add to it.

Signed-off-by: Faseela K <faseela.k@est.tech>