### PR TITLE
Remove gogo-genproto

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ directory in your current working directory. The `artifacts` directory will cont
 ## Running a branch locally
 
 It's easiest to run a build against an org with has all the istio repos forked:
-istio, api, client-go, cni, common-files, envoy, gogo-genproto, pkg, proxy,
+istio, api, client-go, cni, common-files, envoy, pkg, proxy,
 release-builder,test-infra, tools.
 
 If you don’t, the initial cloning of the code will fail.

--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -39,9 +39,6 @@ dependencies:
     git: https://github.com/istio/client-go
     branch: master
     goversionenabled: true
-  gogo-genproto:
-    git: https://github.com/istio/gogo-genproto
-    branch: master
   test-infra:
     git: https://github.com/istio/test-infra
     branch: master

--- a/example/manifest_branch.yaml
+++ b/example/manifest_branch.yaml
@@ -33,9 +33,6 @@ dependencies:
   envoy:
     git: https://github.com/istio/envoy
     branch: master
-  gogo-genproto:
-    git: https://github.com/istio/gogo-genproto
-    branch: master
   pkg:
     git: https://github.com/istio/pkg
     branch: master

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -75,7 +75,6 @@ type IstioDependencies struct {
 	Proxy          *Dependency `json:"proxy"`
 	Pkg            *Dependency `json:"pkg"`
 	ClientGo       *Dependency `json:"client-go"`
-	GogoGenproto   *Dependency `json:"gogo-genproto"`
 	TestInfra      *Dependency `json:"test-infra"`
 	Tools          *Dependency `json:"tools"`
 	Envoy          *Dependency `json:"envoy"`
@@ -91,7 +90,6 @@ func (i *IstioDependencies) Get() map[string]*Dependency {
 		"proxy":           i.Proxy,
 		"pkg":             i.Pkg,
 		"client-go":       i.ClientGo,
-		"gogo-genproto":   i.GogoGenproto,
 		"test-infra":      i.TestInfra,
 		"tools":           i.Tools,
 		"envoy":           i.Envoy,

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -438,7 +438,6 @@ func TestLicenses(r ReleaseInfo) error {
 	// Expect to find license folders for these repos
 	expect := map[string]struct{}{
 		"istio.tar.gz":           {},
-		"gogo-genproto.tar.gz":   {},
 		"client-go.tar.gz":       {},
 		"tools.tar.gz":           {},
 		"test-infra.tar.gz":      {},

--- a/release/branch.sh
+++ b/release/branch.sh
@@ -63,9 +63,6 @@ ${DEPENDENCIES:-$(cat <<EOD
   envoy:
     git: https://github.com/${REPO_ORG}/envoy
     branch: ${BASE_BRANCH}
-  gogo-genproto:
-    git: https://github.com/${REPO_ORG}/gogo-genproto
-    branch: ${BASE_BRANCH}
   pkg:
     git: https://github.com/${REPO_ORG}/pkg
     branch: ${BASE_BRANCH}

--- a/release/build.sh
+++ b/release/build.sh
@@ -72,9 +72,6 @@ ${DEPENDENCIES:-$(cat <<EOD
     git: https://github.com/istio/client-go
     branch: master
     goversionenabled: true
-  gogo-genproto:
-    git: https://github.com/istio/gogo-genproto
-    branch: master
   test-infra:
     git: https://github.com/istio/test-infra
     branch: master

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -57,9 +57,6 @@ dependencies:
     git: https://github.com/istio/client-go
     branch: master
     goversionenabled: true
-  gogo-genproto:
-    git: https://github.com/istio/gogo-genproto
-    branch: master
   test-infra:
     git: https://github.com/istio/test-infra
     branch: master


### PR DESCRIPTION
For https://github.com/istio/istio/pull/38055

Technically we could just do the validate.go change now and the rest
once that merges, but in the end it is all the same.