### PR TITLE
Add multi platforms support for RepoOutDir

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -16,7 +16,9 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"path"
+	"runtime"
 )
 
 type (
@@ -183,12 +185,12 @@ func (m Manifest) RepoDir(repo string) string {
 
 // GoOutDir is a helper to return the directory of Istio build output
 func (m Manifest) GoOutDir() string {
-	return path.Join(m.Directory, "work", "out", "linux_amd64", "release")
+	return path.Join(m.Directory, "work", "out", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH), "release")
 }
 
 // RepoOutDir is a helper to return the directory of Istio build output for repos the place outputs inside the repo
 func (m Manifest) RepoOutDir(repo string) string {
-	return path.Join(m.Directory, "work", "src", "istio.io", repo, "out", "linux_amd64", "release")
+	return path.Join(m.Directory, "work", "src", "istio.io", repo, "out", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH), "release")
 }
 
 // WorkDir is a help to return the work directory


### PR DESCRIPTION
Add multi-platform output dir support for
arm64 and other platforms, which is used in
archive, package(deb, rpm), docker
build actions.

Signed-off-by: TrevorTaoARM <trevor.tao@arm.com>