### PR TITLE
Unset FOR_BUILD_CONTAINER so `make` happens in manifest directories

### DIFF
--- a/pkg/util/command.go
+++ b/pkg/util/command.go
@@ -61,6 +61,7 @@ func RunMake(manifest model.Manifest, repo string, env []string, c ...string) er
 	cmd.Env = removeEnvKey(cmd.Env, "CONTAINER_TARGET_OUT_LINUX")
 	cmd.Env = removeEnvKey(cmd.Env, "TARGET_OS")
 	cmd.Env = removeEnvKey(cmd.Env, "TARGET_ARCH")
+	cmd.Env = removeEnvKey(cmd.Env, "FOR_BUILD_CONTAINER")
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
With recent changes in istio/istio and common-files, a new env variable, FOR_BUILD_CONTAINER, is used to control repo and output directories. 

As release-builder wants `make` artifacts to be created in the manifest directories and not release-builders container directory, this new variable needs to be unset.

The failure appears when trying to run release-builder within a build contianer as documented in the README.