### PR TITLE
fix automation step 3: run prowgen from wd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Contains the built artifacts
 out/
+
+# IDE
+.idea/

--- a/pkg/branch/setupProw.go
+++ b/pkg/branch/setupProw.go
@@ -16,6 +16,7 @@ package branch
 
 import (
 	"fmt"
+	"path"
 
 	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg/model"
@@ -28,14 +29,14 @@ func SetupProw(manifest model.Manifest, release string, dryrun bool) error {
 	log.Infof("*** Updating prow config for new branches.")
 	repo := "test-infra"
 
-	cmd := util.VerboseCommand("go", "run", "tools/prowgen/cmd/prowgen/main.go", "branch", release)
-	cmd.Dir = manifest.RepoDir(repo)
+	cmd := util.VerboseCommand("go", "run", "./cmd/prowgen/main.go", "branch", release)
+	cmd.Dir = path.Join(manifest.RepoDir(repo), "tools/prowgen")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to generate new prow config: %v", err)
 	}
 
-	privateCmd := util.VerboseCommand("go", "run", "tools/generate-transform-jobs/main.go", "branch", release)
-	privateCmd.Dir = manifest.RepoDir(repo)
+	privateCmd := util.VerboseCommand("go", "run", "main.go", "branch", release)
+	cmd.Dir = path.Join(manifest.RepoDir(repo), "tools/generate-transform-jobs")
 	if err := privateCmd.Run(); err != nil {
 		return fmt.Errorf("failed to generate new private prow config: %v", err)
 	}


### PR DESCRIPTION
`go run ./tools/prowgen/cmd/prowgen/main.go` breaks but `cd tools/prowgen; go run ./cmd/prowgen` works (using the correct go.mod)
using release builder automation: 

```
2022-04-21T21:52:14.511034Z    info    *** Updating prow config for new branches.
2022-04-21T21:52:14.511092Z    info    Running command: go run tools/prowgen/cmd/prowgen/main.go branch 1.14
tools/prowgen/cmd/prowgen/main.go:29:2: missing go.sum entry for module providing package [github.com/kballard/go-shellquote](http://github.com/kballard/go-shellquote); to add:
    go mod download [github.com/kballard/go-shellquote](http://github.com/kballard/go-shellquote)
tools/prowgen/cmd/prowgen/main.go:33:2: no required module provides package [istio.io/test-infra/tools/prowgen/pkg](http://istio.io/test-infra/tools/prowgen/pkg); to add it:
    go get [istio.io/test-infra/tools/prowgen/pkg](http://istio.io/test-infra/tools/prowgen/pkg)
tools/prowgen/cmd/prowgen/main.go:34:2: no required module provides package [istio.io/test-infra/tools/prowgen/pkg/spec](http://istio.io/test-infra/tools/prowgen/pkg/spec); to add it:
    go get [istio.io/test-infra/tools/prowgen/pkg/spec](http://istio.io/test-infra/tools/prowgen/pkg/spec)
Error: failed to branch: failed to setup prow: failed to generate new prow config: exit status 1
```