### PR TITLE
Update cosign flag

### DIFF
--- a/pkg/publish/cmd.go
+++ b/pkg/publish/cmd.go
@@ -89,7 +89,7 @@ func init() {
 	publishCmd.PersistentFlags().StringVar(&flags.grafanatoken, "grafanatoken", flags.grafanatoken,
 		"The file containing a grafana.com API token.")
 	publishCmd.PersistentFlags().StringVar(&flags.cosignkey, "cosignkey", flags.cosignkey,
-		"A key for signing images, as passed to cosign using 'cosign sign -key <x>'")
+		"A key for signing images, as passed to cosign using 'cosign sign --key <x>'")
 }
 
 func GetPublishCommand() *cobra.Command {

--- a/pkg/publish/docker.go
+++ b/pkg/publish/docker.go
@@ -39,7 +39,7 @@ func Docker(manifest model.Manifest, hub string, tags []string, cosignkey string
 	// able to run 'cosign public-key <key>'.
 	cosignEnabled := false
 	if cosignkey != "" {
-		if err := util.VerboseCommand("cosign", "public-key", "-key", cosignkey).Run(); err != nil {
+		if err := util.VerboseCommand("cosign", "public-key", "--key", cosignkey).Run(); err != nil {
 			log.Errorf("Argument '--cosignkey' nonempty but unable to access key %v, disabling signing.", err)
 		} else {
 			cosignEnabled = true
@@ -84,7 +84,7 @@ func Docker(manifest model.Manifest, hub string, tags []string, cosignkey string
 				// Sign images *after* push -- cosign only works against real
 				// repositories (not valid against tarballs)
 				if cosignEnabled {
-					if err := util.VerboseCommand("cosign", "sign", "-key", cosignkey, newTag).Run(); err != nil {
+					if err := util.VerboseCommand("cosign", "sign", "--key", cosignkey, newTag).Run(); err != nil {
 						return fmt.Errorf("failed to sign image %v with key %v: %v", newTag, cosignkey, err)
 					}
 				}


### PR DESCRIPTION
I notice in the release-builder logs:
```
2022-05-05T20:06:25.185768Z	info	Running command: cosign sign -key gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1 docker.io/istio/app:1.14.0-alpha.0
WARNING: the flag -key is deprecated and will be removed in a future release. Please use the flag --key.
```

Update the two commands to use `--key`