### PR TITLE
Fix helm index race condition

### DIFF
--- a/pkg/publish/gcs.go
+++ b/pkg/publish/gcs.go
@@ -17,14 +17,17 @@ package publish
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
 
 	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg/model"
@@ -89,3 +92,85 @@ func GcsArchive(manifest model.Manifest, bucket string, aliases []string) error 
 
 	return nil
 }
+
+// MutateObject allows pulling a file from GCS, mutating it, then pushing it back up. This adds checks
+// to ensure that if the file is mutated in the meantime, the process is repeated.
+func MutateObject(outDir string, bkt *storage.BucketHandle, objectPrefix string, filename string, f func() error) error {
+	for i := 0; i < 10; i++ {
+		err := mutateObjectInner(outDir, bkt, objectPrefix, filename, f)
+		if err == ErrIndexOutOfDate {
+			log.Warnf("Write conflict, trying again")
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("max conflicts attempted")
+}
+
+func mutateObjectInner(outDir string, bkt *storage.BucketHandle, objectPrefix string, filename string, f func() error) error {
+	objName := filepath.Join(objectPrefix, filename)
+	outFile := filepath.Join(outDir, filename)
+	obj := bkt.Object(objName)
+	attr, err := obj.Attrs(context.Background())
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			// Missing is fine
+			log.Warnf("existing file %v does not exist", filename)
+		} else {
+			return fmt.Errorf("failed to fetch attributes: %v", err)
+		}
+	}
+	generation := int64(0)
+	if attr != nil {
+		generation = attr.Generation
+		log.Infof("Object %v currently has generation %d", objName, generation)
+
+		r, err := obj.NewReader(context.Background())
+		if err != nil {
+			if err == storage.ErrObjectNotExist {
+				// This may be fine if we are publishing for the first time. Helm will allow us to `--merge non-existing-file.yaml`.
+				log.Warnf("existing file %v does not exist", filename)
+				return nil
+			}
+			return err
+		}
+		idx, err := ioutil.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(outFile, idx, 0o644); err != nil {
+			return err
+		}
+		r.Close()
+		log.Infof("Wrote %v", outFile)
+	}
+
+	// Run our action
+	if err := f(); err != nil {
+		return fmt.Errorf("action failed: %v", err)
+	}
+
+	// Now we want to (try to) write it
+	o := obj
+	if generation > 0 {
+		o = o.If(storage.Conditions{GenerationMatch: generation})
+	}
+	w := o.NewWriter(context.Background())
+	res, err := os.Open(outFile)
+	if err != nil {
+		return fmt.Errorf("failed to open %v: %v", res.Name(), err)
+	}
+	if _, err := io.Copy(w, bufio.NewReader(res)); err != nil {
+		return fmt.Errorf("failed writing %v: %v", res.Name(), err)
+	}
+	if err := w.Close(); err != nil {
+		gerr, ok := err.(*googleapi.Error)
+		if ok && gerr.Code == 412 {
+			return ErrIndexOutOfDate
+		}
+		return fmt.Errorf("failed to close bucket: %v", err)
+	}
+	return nil
+}
+
+var ErrIndexOutOfDate = errors.New("index is out-of-date")

--- a/pkg/publish/helm.go
+++ b/pkg/publish/helm.go
@@ -68,30 +68,33 @@ func publishHelmIndex(manifest model.Manifest, bucket string) error {
 
 	helmDir := filepath.Join(manifest.Directory, "helm")
 
-	// First pull down the current index, so we can merge it. This has a race, but we are extremely unlikely
-	// to publish two versions in the same second
-	if err := fetchCurrentIndex(helmDir, bkt, objectPrefix); err != nil {
-		return fmt.Errorf("fetch index: %v", err)
+	// Pull down the index, update it, and push it back up.
+	// MutateObject ensures there are no races.
+	err = MutateObject(helmDir, bkt, objectPrefix, "index.yaml", func() error {
+		idxCmd := util.VerboseCommand("helm", "repo", "index", ".",
+			"--url", fmt.Sprintf("https://%s.storage.googleapis.com/%s", bucketName, objectPrefix),
+			"--merge", "index.yaml")
+		idxCmd.Dir = helmDir
+		log.Infof("Running helm repo index with dir %v", idxCmd.Dir)
+		if err := idxCmd.Run(); err != nil {
+			return fmt.Errorf("index repo: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("helm publish: %v", err)
 	}
+
+	// Now push all our charts up
 	dirInfo, err := ioutil.ReadDir(helmDir)
 	if err != nil {
 		return err
 	}
-
-	// Create a new index, merging the existing one with our new charts
-	idxCmd := util.VerboseCommand("helm", "repo", "index", ".",
-		"--url", fmt.Sprintf("https://%s.storage.googleapis.com/%s", bucketName, objectPrefix),
-		"--merge", "index.yaml")
-	idxCmd.Dir = helmDir
-	log.Infof("Running helm repo index with dir %v", idxCmd.Dir)
 	for _, f := range dirInfo {
-		log.Infof("dir containers: %v", f.Name())
-	}
-	if err := idxCmd.Run(); err != nil {
-		return fmt.Errorf("index repo: %v", err)
-	}
-
-	for _, f := range dirInfo {
+		if filepath.Ext(f.Name()) != ".tgz" {
+			log.Infof("skipping %v", f.Name())
+			continue
+		}
 		objName := path.Join(objectPrefix, f.Name())
 		obj := bkt.Object(objName)
 		w := obj.NewWriter(ctx)
@@ -126,27 +129,6 @@ func publishHelmOCI(manifest model.Manifest, hub string) error {
 		if err := util.VerboseCommand("helm", "push", name, "oci://"+hub).Run(); err != nil {
 			return fmt.Errorf("failed to load docker image %v: %v", f.Name(), err)
 		}
-	}
-	return nil
-}
-
-func fetchCurrentIndex(outDir string, bkt *storage.BucketHandle, objectPrefix string) error {
-	r, err := bkt.Object(filepath.Join(objectPrefix, "index.yaml")).NewReader(context.Background())
-	if err != nil {
-		if err == storage.ErrObjectNotExist {
-			// This may be fine if we are publishing for the first time. Helm will allow us to `--merge non-existing-file.yaml`.
-			log.Warnf("existing index.yaml does not exist")
-			return nil
-		}
-		return err
-	}
-	defer r.Close()
-	idx, err := ioutil.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	if err := ioutil.WriteFile(filepath.Join(outDir, "index.yaml"), idx, 0o644); err != nil {
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
We keep having issues with helm charts not being publish. I was able to
root cause this to a race in two jobs. I think this mostly happens with
security releases when we do multiple versions at once.

This updates the GCS writes to be safe.

I tested this with a dummy script that appends the size of the file:
```
	d, err := ioutil.TempDir("/tmp", "race")
	ctx := context.Background()
	client, err := storage.NewClient(ctx)
	if err != nil {
		panic(err.Error())
	}
	bkt := client.Bucket("howardjohn")
	fmt.Println(publish.MutateObject(d, bkt, "tmp", "race", func() error {
		c := exec.Command("sh", "-c", fmt.Sprintf(`
c="$(cat %s/race | wc -l)"
echo $c >> %s/race
echo "Wrote $c"
`, d, d))
		c.Stdout = os.Stdout
		c.Stderr = os.Stderr
		return c.Run()
	}))
```

and ran it many times in parallel.