### PR TITLE
[1.13] Fix helm index race condition (#1098)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/rogpeppe/go-internal v1.8.1
 	github.com/spf13/cobra v1.3.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	google.golang.org/api v0.62.0
 	istio.io/pkg v0.0.0-20220110182003-89d2d53e36e1
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -54,7 +55,6 @@ require (
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	google.golang.org/api v0.62.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/grpc v1.42.0 // indirect

--- a/pkg/publish/gcs.go
+++ b/pkg/publish/gcs.go
@@ -17,14 +17,17 @@ package publish
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
 
 	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg/model"
@@ -89,3 +92,85 @@ func GcsArchive(manifest model.Manifest, bucket string, aliases []string) error 
 
 	return nil
 }
+
+// MutateObject allows pulling a file from GCS, mutating it, then pushing it back up. This adds checks
+// to ensure that if the file is mutated in the meantime, the process is repeated.
+func MutateObject(outDir string, bkt *storage.BucketHandle, objectPrefix string, filename string, f func() error) error {
+	for i := 0; i < 10; i++ {
+		err := mutateObjectInner(outDir, bkt, objectPrefix, filename, f)
+		if err == ErrIndexOutOfDate {
+			log.Warnf("Write conflict, trying again")
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("max conflicts attempted")
+}
+
+func mutateObjectInner(outDir string, bkt *storage.BucketHandle, objectPrefix string, filename string, f func() error) error {
+	objName := filepath.Join(objectPrefix, filename)
+	outFile := filepath.Join(outDir, filename)
+	obj := bkt.Object(objName)
+	attr, err := obj.Attrs(context.Background())
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			// Missing is fine
+			log.Warnf("existing file %v does not exist", filename)
+		} else {
+			return fmt.Errorf("failed to fetch attributes: %v", err)
+		}
+	}
+	generation := int64(0)
+	if attr != nil {
+		generation = attr.Generation
+		log.Infof("Object %v currently has generation %d", objName, generation)
+
+		r, err := obj.NewReader(context.Background())
+		if err != nil {
+			if err == storage.ErrObjectNotExist {
+				// This may be fine if we are publishing for the first time. Helm will allow us to `--merge non-existing-file.yaml`.
+				log.Warnf("existing file %v does not exist", filename)
+				return nil
+			}
+			return err
+		}
+		idx, err := ioutil.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(outFile, idx, 0o644); err != nil {
+			return err
+		}
+		r.Close()
+		log.Infof("Wrote %v", outFile)
+	}
+
+	// Run our action
+	if err := f(); err != nil {
+		return fmt.Errorf("action failed: %v", err)
+	}
+
+	// Now we want to (try to) write it
+	o := obj
+	if generation > 0 {
+		o = o.If(storage.Conditions{GenerationMatch: generation})
+	}
+	w := o.NewWriter(context.Background())
+	res, err := os.Open(outFile)
+	if err != nil {
+		return fmt.Errorf("failed to open %v: %v", res.Name(), err)
+	}
+	if _, err := io.Copy(w, bufio.NewReader(res)); err != nil {
+		return fmt.Errorf("failed writing %v: %v", res.Name(), err)
+	}
+	if err := w.Close(); err != nil {
+		gerr, ok := err.(*googleapi.Error)
+		if ok && gerr.Code == 412 {
+			return ErrIndexOutOfDate
+		}
+		return fmt.Errorf("failed to close bucket: %v", err)
+	}
+	return nil
+}
+
+var ErrIndexOutOfDate = errors.New("index is out-of-date")


### PR DESCRIPTION
* Fix helm index race condition

We keep having issues with helm charts not being publish. I was able to
root cause this to a race in two jobs. I think this mostly happens with
security releases when we do multiple versions at once.

This updates the GCS writes to be safe.

* mods

(cherry picked from commit cde6a6b46cef19cb44fe1c29571c97e64e178b13)