### PR TITLE
helm publish: disable caching

### DIFF
--- a/pkg/publish/gcs.go
+++ b/pkg/publish/gcs.go
@@ -169,6 +169,14 @@ func mutateObjectInner(outDir string, bkt *storage.BucketHandle, objectPrefix st
 		o = o.If(storage.Conditions{GenerationMatch: generation})
 	}
 	w := o.NewWriter(context.Background())
+
+	// Ensure we do not cache. This would be fine for normal users reading, but it ends up making the release process
+	// break if we have multiple releases too quickly (default cache is 1hr).
+	w.CacheControl = "no-cache, max-age=0, no-transform"
+
+	// https://helm.sh/docs/topics/chart_repository/#ordinary-web-servers
+	w.ContentType = "text/yaml"
+
 	res, err := os.Open(outFile)
 	if err != nil {
 		return fmt.Errorf("failed to open %v: %v", res.Name(), err)


### PR DESCRIPTION
The issue with publishing is we have cached reads, so subsequent builds (within 1hr, default cache) will pull down the old data then overwrite.

This disables caching