### PR TITLE
Add warning notes if helm charts Istio version is already EOL

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -154,6 +154,29 @@ func sanitizeChart(manifest model.Manifest, s string) error {
 				return err
 			}
 		}
+
+		if fname == "NOTES.txt" {
+			read, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			contents := string(read)
+
+			EOLTemplate := `
+{{- $EndOfLife := toDate "2006-01" "%s" | unixEpoch -}}
+{{- $Now := now | unixEpoch -}}
+
+{{- if ge $Now $EndOfLife}}
+
+WARNING: may be installing an EOL version: see https://istio.io/latest/docs/releases/supported-releases/ for supported releases
+{{ end }}
+`
+			contents = contents + fmt.Sprintf(EOLTemplate, manifest.EOLDate)
+			err = os.WriteFile(p, []byte(contents), 0)
+			if err != nil {
+				return err
+			}
+		}
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/manifest.go
+++ b/pkg/manifest.go
@@ -74,6 +74,7 @@ func InputManifestToManifest(in model.InputManifest) (model.Manifest, error) {
 	return model.Manifest{
 		Dependencies:                in.Dependencies,
 		Version:                     in.Version,
+		EOLDate:                     in.EOLDate,
 		Docker:                      in.Docker,
 		DockerOutput:                do,
 		Directory:                   wd,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -131,6 +131,9 @@ type InputManifest struct {
 	Dependencies IstioDependencies `json:"dependencies"`
 	// Version specifies what version of Istio this release is
 	Version string `json:"version"`
+	// EOLDate specifies what is the date when this Istio version become EOL
+	// Should be in format "yyyy-mm"
+	EOLDate string `json:"eolDate"`
 	// Docker specifies the docker hub to use in the helm charts.
 	Docker string `json:"docker"`
 	// DockerOutput specifies where docker images are written.
@@ -160,6 +163,9 @@ type Manifest struct {
 	Dependencies IstioDependencies `json:"dependencies"`
 	// Version specifies what version of Istio this release is
 	Version string `json:"version"`
+	// EOLDate specifies what is the date when this Istio version become EOL
+	// Should be in format "yyyy-mm"
+	EOLDate string `json:"eolDate"`
 	// Docker specifies the docker hub to use in the helm charts.
 	Docker string `json:"docker"`
 	// DockerOutput specifies where docker images are written.


### PR DESCRIPTION
Signed-off-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>

fix https://github.com/istio/istio/issues/41747, introduce a warning if the current date is near or after EOL of the date defined in the release builder.

![image](https://user-images.githubusercontent.com/11990726/206217999-55852acb-66bb-4c0b-8142-8b9e92a703c6.png)
