### PR TITLE
Also create a new branch in istio/repo (need in step 4)

### DIFF
--- a/pkg/branch/createBranches.go
+++ b/pkg/branch/createBranches.go
@@ -34,7 +34,7 @@ func CreateBranches(manifest model.Manifest, release string, dryrun bool) error 
 		}
 		// test-infra does not use release branches and envoy repo should be manually branched
 		// from correct envoy commit
-		if repo == "test-infra" || repo == "envoy" {
+		if repo == "test-infra" {
 			log.Infof("Skipping repo: %v", repo)
 			continue
 		}


### PR DESCRIPTION
During the 1.17 branch cutting it was noted that step 4 needs to process istio/envoy and the branch wasn't created in step 2.