### PR TITLE
Use `ISTIO_BASE_REGISTRY` to scan base image when it is set

### DIFF
--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -60,7 +60,12 @@ func Scanner(manifest model.Manifest, githubToken, git, branch string) error {
 	baseVersion := strings.TrimSpace(strings.Split(out.String(), " ")[2]) // Assumes line of the form BASE_VERSION ?= baseVersion
 
 	// Call image scanner passing in base image name. If request times out, retry the request
-	baseImageName := "istio/base:" + baseVersion
+	istioBaseRegistry := os.Getenv("ISTIO_BASE_REGISTRY")
+	if istioBaseRegistry == "" {
+		istioBaseRegistry = "istio"
+	}
+	baseImageName := istioBaseRegistry + "/base:" + baseVersion
+
 	trivyScanOutput, err := util.RunWithOutput("trivy", "image", "--ignore-unfixed", "--no-progress", "--exit-code", "2", baseImageName)
 	if err == nil {
 		log.Infof("Base image scan of %s was successful", baseImageName)


### PR DESCRIPTION
Allow `ISTIO_BASE_REGISTRY` to be used when scanning base images or default to istio. We are building our own base images and found that it breaks when trying to scan. This env var is already used elsewhere. 
Example: https://github.com/istio/istio/blob/5e26759e42b80be9c84f958d1ad842deb5a77cb0/operator/docker/Dockerfile.operator#L9