### PR TITLE
Fix cosign signing

### DIFF
--- a/pkg/publish/docker.go
+++ b/pkg/publish/docker.go
@@ -91,7 +91,7 @@ func Docker(manifest model.Manifest, hub string, tags []string, cosignkey string
 	// able to run 'cosign public-key <key>'.
 	cosignEnabled := false
 	if cosignkey != "" {
-		if err := util.VerboseCommand("cosign", "public-key", "--key", cosignkey, "-y").Run(); err != nil {
+		if err := util.VerboseCommand("cosign", "public-key", "--key", cosignkey).Run(); err != nil {
 			log.Errorf("Argument '--cosignkey' nonempty but unable to access key %v, disabling signing.", err)
 		} else {
 			cosignEnabled = true


### PR DESCRIPTION
Looking to verify `cosign` on the main branch which was used for the 1.18.0-alpha.0 publish
```
cosign verify --key "https://istio.io/misc/istio-key.pub" istio/pilot:1.18.0-alpha.0
Error: no signatures found for image
main.go:69: error during command execution: no signatures found for image
```

Looking at the 1.18.0-alpha.0 publish logs I see:
```
2023-03-03T21:23:18.829511Z	info	Running command: cosign public-key --key gcpkms://projects/istio-prow-build/locations/global/keyRings/istio-cosign-keyring/cryptoKeys/istio-cosign-key/versions/1 -y
Error: unknown shorthand flag: 'y' in -y
main.go:74: error during command execution: unknown shorthand flag: 'y' in -y
2023-03-03T21:23:19.406841Z	error	Argument '--cosignkey' nonempty but unable to access key exit status 1, disabling signing.
```
In a prior PR, the `-y` was added to the `cosign public-key` when it shouldn't have been. This simply removes the flag on the one command.

