### PR TITLE
drop kustomize from helm chart

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -169,12 +169,37 @@ func HelmCharts(manifest model.Manifest) error {
 		return fmt.Errorf("failed to make destination directory %v: %v", dst, err)
 	}
 	for _, chart := range repoHelmCharts {
-		dir := path.Join(manifest.RepoDir("istio"), chart)
-		c := util.VerboseCommand("helm", "package", dir)
+		inDir := path.Join(manifest.RepoDir("istio"), chart)
+		outDir := path.Join(manifest.WorkDir(), "charts", chart)
+		if err := util.CopyDir(inDir, outDir); err != nil {
+			return err
+		}
+		if err := dropKustomize(outDir); err != nil {
+			return err
+		}
+		c := util.VerboseCommand("helm", "package", outDir)
 		c.Dir = dst
 		if err := c.Run(); err != nil {
 			return fmt.Errorf("package %v: %v", chart, err)
 		}
 	}
 	return nil
+}
+
+// Workaround for https://github.com/istio/istio/issues/44237. Eventually we will remove kustomize entirely,
+// but this is for backwards compat to remove it just from Helm charts.
+func dropKustomize(dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		// Check if the file name is "kustomization.yaml"
+		if info.Name() == "kustomization.yaml" {
+			// Delete the file
+			if err := os.Remove(path); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
## Summary
- Resolves #1450 — automated nightly merge of `upstream/release-1.30` hit conflicts in `release/build.sh`, `release/trigger-build`, and `release/trigger-publish`.
- `release/build.sh`: kept Solo fork repos (`solo-io/*`); pointed `istio` and `release-builder` at `release-1.30-solo-fips`, `tools` at `release-1.30`. Matches the final state of release-1.29-solo-fips.
- `release/trigger-build` / `release/trigger-publish`: kept HEAD values per the Solo convention of not tracking upstream version bumps. Bump these separately when starting 1.30 Solo builds.

## Test plan
- [ ] CI passes on this branch
- [ ] Confirm `release/build.sh` points at the correct Solo branches for a 1.30 build