### PR TITLE
Remove istio.io/pkg from the manifest

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -76,9 +76,6 @@ ${DEPENDENCIES:-$(cat <<EOD
   ztunnel:
     git: https://github.com/${GITHUB_ORG}/ztunnel
     auto: deps
-  pkg:
-    git: https://github.com/${GITHUB_ORG}/pkg
-    auto: modules
   client-go:
     git: https://github.com/${GITHUB_ORG}/client-go
     branch: master


### PR DESCRIPTION
Not sure if we want to remove this as other repos are using this folder to help build istio. Thoughts?

See https://github.com/istio/release-builder/blob/3e098023e5dc6ad036accec5354bdbc2c70b126e/go.mod#L15