### PR TITLE
Test proxyversion from binary version

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ the latest SHAs of commits.
     For example, later versions of Docker Desktop for Mac may require an environment variable set so the build
     container can communincate with Docker on the host.
 
+1. Run `docker buildx inspect`. This will return the information about the current builder. If the current builder `Driver` is not `docker-container`, you need to create one:
+
+    ```
+    docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.11.0 --name istio-builder --driver docker-container --buildkitd-flags="--debug" --use
+    ```
+
 1. Run `crane digest gcr.io/distroless/static-debian11`. If you see an error like:
 
     ```text

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -248,7 +248,7 @@ func TestProxyVersion(r ReleaseInfo) error {
 		return fmt.Errorf("failed to load proxyv2-debug.tar.gz as docker image: %v", err)
 	}
 	buf := bytes.Buffer{}
-	image := fmt.Sprintf("%s:%s", "istio/proxyv2", r.manifest.Version)
+	image := fmt.Sprintf("%s/%s:%s", r.manifest.Docker, "proxyv2", r.manifest.Version)
 	cmd := util.VerboseCommand("docker", "run", "--rm", image, "version", "--short")
 	cmd.Stdout = &buf
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Contributes to [#44937](https://github.com/istio/istio/issues/44937)

This PR changes `TestProxyVersion` check: the version is not checked from the proxy docker image ISTIO_META_ISTIO_VERSION environment variable anymore, but from the binary version (loading the `tar.gz` as docker image, and running the container with `version --short`