### PR TITLE
testing: move test publish to use local storage

### DIFF
--- a/pkg/publish/gcs.go
+++ b/pkg/publish/gcs.go
@@ -27,15 +27,26 @@ import (
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/release-builder/pkg/model"
 )
 
+func NewGCSClient(ctx context.Context) (*storage.Client, error) {
+	opts := []option.ClientOption{}
+	if host := os.Getenv("GCS_HOST"); host != "" {
+		// For testing
+		log.Infof("using custom GCS_HOST: %v", host)
+		opts = append(opts, option.WithEndpoint(host))
+	}
+	return storage.NewClient(ctx, opts...)
+}
+
 // GcsArchive publishes the final release archive to the given GCS bucket
 func GcsArchive(manifest model.Manifest, bucket string, aliases []string) error {
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
+	client, err := NewGCSClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 		return err

--- a/pkg/publish/helm.go
+++ b/pkg/publish/helm.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"cloud.google.com/go/storage"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/log"
@@ -51,7 +50,7 @@ func Helm(manifest model.Manifest, bucket string, hub string) error {
 
 func publishHelmIndex(manifest model.Manifest, bucket string) error {
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
+	client, err := NewGCSClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/release/branch.sh
+++ b/release/branch.sh
@@ -83,7 +83,4 @@ EOD
 EOF
 )
 
-# "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
-
 go run main.go branch --manifest <(echo "${MANIFEST}") --step="${STEP}" --dryrun="${DRY_RUN}" --githubtoken "${GITHUB_TOKEN_FILE}"

--- a/release/build.sh
+++ b/release/build.sh
@@ -106,9 +106,6 @@ ${PROXY_OVERRIDE:-}
 EOF
 )
 
-# "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
-
 if [ "$BUILD_BASE_IMAGES" = true ] ; then
   # For build, don't use GITHUB_TOKEN_FILE env var set by preset-release-pipeline
   # which is pointing to the github token for istio-release-robot. Instead point to

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -51,9 +51,6 @@ COSIGN_KEY=${COSIGN_KEY:-}
 WORK_DIR="$(mktemp -d)/release"
 mkdir -p "${WORK_DIR}"
 
-# "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
-
 gsutil -m cp -r "gs://${SOURCE_GCS_BUCKET}/${VERSION}/*" "${WORK_DIR}"
 go run main.go publish --release "${WORK_DIR}" \
     --cosignkey "${COSIGN_KEY:-}" \


### PR DESCRIPTION
Currently we publsih to GCS and GCR. This moves to using a fake GCS
backend and local docker registry, allowing this to be run without any
privileges. We should still get 99% of the test coverage which is good
enough.
