### PR TITLE
testing: move test publish to use local storage (#1527)

### DIFF
--- a/pkg/publish/gcs.go
+++ b/pkg/publish/gcs.go
@@ -27,15 +27,26 @@ import (
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 
 	"istio.io/pkg/log"
 	"istio.io/release-builder/pkg/model"
 )
 
+func NewGCSClient(ctx context.Context) (*storage.Client, error) {
+	opts := []option.ClientOption{}
+	if host := os.Getenv("GCS_HOST"); host != "" {
+		// For testing
+		log.Infof("using custom GCS_HOST: %v", host)
+		opts = append(opts, option.WithEndpoint(host))
+	}
+	return storage.NewClient(ctx, opts...)
+}
+
 // GcsArchive publishes the final release archive to the given GCS bucket
 func GcsArchive(manifest model.Manifest, bucket string, aliases []string) error {
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
+	client, err := NewGCSClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 		return err

--- a/pkg/publish/helm.go
+++ b/pkg/publish/helm.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"cloud.google.com/go/storage"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/pkg/log"
@@ -51,7 +50,7 @@ func Helm(manifest model.Manifest, bucket string, hub string) error {
 
 func publishHelmIndex(manifest model.Manifest, bucket string) error {
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
+	client, err := NewGCSClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/release/branch.sh
+++ b/release/branch.sh
@@ -83,7 +83,4 @@ EOD
 EOF
 )
 
-# "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
-
 go run main.go branch --manifest <(echo "${MANIFEST}") --step="${STEP}" --dryrun="${DRY_RUN}" --githubtoken "${GITHUB_TOKEN_FILE}"

--- a/release/build.sh
+++ b/release/build.sh
@@ -102,9 +102,6 @@ ${PROXY_OVERRIDE:-}
 EOF
 )
 
-# "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
-
 if [ $BUILD_BASE_IMAGES = true ] ; then
   # For build, don't use GITHUB_TOKEN_FILE env var set by preset-release-pipeline
   # which is pointing to the github token for istio-release-robot. Instead point to

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -49,9 +49,6 @@ COSIGN_KEY=${COSIGN_KEY:-}
 WORK_DIR="$(mktemp -d)/release"
 mkdir -p "${WORK_DIR}"
 
-# "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
-
 gsutil -m cp -r "gs://${SOURCE_GCS_BUCKET}/${VERSION}/*" "${WORK_DIR}"
 go run main.go publish --release "${WORK_DIR}" \
     --cosignkey "${COSIGN_KEY:-}" \

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -27,7 +27,39 @@ else
   echo "No credential helpers found, push to docker may not function properly"
 fi
 
-DOCKER_HUB=${DOCKER_HUB:-gcr.io/istio-testing}
+function cleanup() {
+  # shellcheck disable=SC2046
+  docker stop $(docker ps -a -q --filter label=istio-release-builder)
+}
+trap cleanup EXIT
+
+# Setup fake GCS and registry
+docker run -d  --rm  \
+  -p "7480:5000" --label istio-release-builder \
+  --name "release-builder-registry" \
+  gcr.io/istio-testing/registry:2
+docker run -d  --rm  \
+  -p "7481:7481" --label istio-release-builder \
+  --name "release-builder-gcs" \
+  gcr.io/istio-testing/fake-gcs-server:1.45.2 \
+  -scheme http -port 7481
+
+# Setup our bucket. Add retry since the registry may not be ready yet
+counter=0
+while : ; do
+  [[ "$counter" == 10 ]] && exit 1
+  curl -X POST \
+    -d '{"name":"istio-build"}' \
+    -H "content-type: application/json" \
+    -H "accept: application/json" \
+    'http://127.0.0.1:7481/storage/v1/b?alt=json&project=test&projection=full' && break
+   sleep 1
+   echo "Trying again... Try #$counter"
+   counter=$((counter+1))
+done
+
+DOCKER_HUB=${DOCKER_HUB:-"localhost:7480"}
+export GCS_HOST=${GCS_HOST-"http://localhost:7481"}
 GCS_BUCKET=${GCS_BUCKET:-istio-build/test}
 HELM_BUCKET=${HELM_BUCKET:-istio-build/test/charts}
 VERSION="1.14.0-releasebuilder.$(git rev-parse --short HEAD)"
@@ -79,9 +111,6 @@ dashboards:
 EOF
 )
 
-# "Temporary" hacks
-export PATH=${GOPATH}/bin:${PATH}
-
 go run main.go build --manifest <(echo "${MANIFEST}")
 
 go run main.go validate --release "${WORK_DIR}/out"
@@ -94,5 +123,4 @@ go run main.go publish --release "${WORK_DIR}/out" \
   --gcsbucket "${GCS_BUCKET}" \
   --dockerhub "${DOCKER_HUB}" \
   --dockertags "${VERSION}"
-
 fi


### PR DESCRIPTION
Currently we publsih to GCS and GCR. This moves to using a fake GCS
backend and local docker registry, allowing this to be run without any
privileges. We should still get 99% of the test coverage which is good
enough.

(cherry picked from commit 5926c1a9e23e71eeefe3f323b1a2364eeab2c609)
