### PR TITLE
Stop hardcoding github token file

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -106,12 +106,7 @@ ${PROXY_OVERRIDE:-}
 EOF
 )
 
-if [ "$BUILD_BASE_IMAGES" = true ] ; then
-  # For build, don't use GITHUB_TOKEN_FILE env var set by preset-release-pipeline
-  # which is pointing to the github token for istio-release-robot. Instead point to
-  # the github token for istio-testing. The token is currently only used to create the
-  # PR to update the build image.
-  GITHUB_TOKEN_FILE=/etc/github-token/oauth
+if [[ "$BUILD_BASE_IMAGES" == "true" ]]; then
   MANIFEST=$(cat <<EOF
 version: "${VERSION}"
 docker: "${DOCKER_HUB}"
@@ -125,7 +120,7 @@ EOF
 )
   go run main.go build \
     --manifest <(echo "${MANIFEST}") \
-    --githubtoken "${GITHUB_TOKEN_FILE}" \
+    --githubtoken "${GITHUB_TOKEN_FILE:-}" \
     --build-base-images
   exit 0
 fi


### PR DESCRIPTION
we will not use a file, but rather inline in env var. 

note: this will break the job for a bit. We can add backwards compat if we want, or just merge the followup