### PR TITLE
Allow GH_TOKEN and GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The automated `STEPS`:
 
 The following credentials are needed
 
-* Github token: as environment variable `GITHUB_TOKEN` or `--githubtoken file`.
+* Github token: as environment variable `GITHUB_TOKEN`, `GH_TOKEN`, or `--githubtoken file`.
 * Docker credentials (if publishing to docker) (TODO - how to set these).
 * GCP credentials (if publishing to GCS) (TODO - how to set these).
 * Grafana credentials (if publishing to grafana): as environment variable `GRAFANA_TOKEN` or `--grafanatoken file`.

--- a/pkg/util/git.go
+++ b/pkg/util/git.go
@@ -197,5 +197,8 @@ func GetGithubToken(file string) (string, error) {
 		}
 		return strings.TrimSpace(string(b)), nil
 	}
+	if t, f := os.LookupEnv("GH_TOKEN"); f {
+		return t, nil
+	}
 	return os.Getenv("GITHUB_TOKEN"), nil
 }


### PR DESCRIPTION
Everywhere else uses GH_TOKEN, I think by allowing both it will make things easier to use a consistent var between everything