### PR TITLE
Cleanup base image building to use explicit script

### DIFF
--- a/pkg/source.go
+++ b/pkg/source.go
@@ -95,6 +95,10 @@ func SetupWorkDir(dir string) error {
 
 // TagRepo tags a given git repo with the version from the manifest.
 func TagRepo(manifest model.Manifest, repo string) error {
+	if manifest.Version == "" {
+		log.Warnf("skip tagging, version not set")
+		return nil
+	}
 	headSha, err := GetSha(repo, "HEAD")
 	if err != nil {
 		return fmt.Errorf("failed to get HEAD SHA: %v", err)

--- a/pkg/source.go
+++ b/pkg/source.go
@@ -95,10 +95,6 @@ func SetupWorkDir(dir string) error {
 
 // TagRepo tags a given git repo with the version from the manifest.
 func TagRepo(manifest model.Manifest, repo string) error {
-	if manifest.Version == "" {
-		log.Warnf("skip tagging, version not set")
-		return nil
-	}
 	headSha, err := GetSha(repo, "HEAD")
 	if err != nil {
 		return fmt.Errorf("failed to get HEAD SHA: %v", err)

--- a/release/build-base-images.sh
+++ b/release/build-base-images.sh
@@ -48,6 +48,7 @@ WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"
 
 MANIFEST=$(cat <<EOF
+version: "${VERSION}"
 directory: "${WORK_DIR}"
 dependencies:
   istio:

--- a/release/build-base-images.sh
+++ b/release/build-base-images.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# Ensure we are running from the repo root
+cd "${ROOT}"
+
+set -eux
+
+if [[ -n "${DOCKER_CONFIG_DATA:-}" ]]; then
+  # Custom docker config as inline environment variable
+  mkdir ~/.docker
+  set +x
+  echo "${DOCKER_CONFIG_DATA}" > ~/.docker/config.json
+  set -x
+  export DOCKER_CONFIG=~/.docker
+  gcloud auth configure-docker -q
+elif [[ -n "${DOCKER_CONFIG:-}" ]]; then
+  # If DOCKER_CONFIG is set, we are mounting a known docker config.
+  # we will want to merge in gcloud options, so we can push to GCR *and* the other (docker hub) credentials.
+  # However, DOCKER_CONFIG is a read only mount. So we copy it to somewhere writeable then merge in the GCR creds
+  mkdir ~/.docker
+  cp "${DOCKER_CONFIG}/config.json" ~/.docker/
+  export DOCKER_CONFIG=~/.docker
+  gcloud auth configure-docker -q
+fi
+# No else needed - the prow entrypoint already runs configure-docker for standard cases
+
+GITHUB_ORG=${GITHUB_ORG:-istio}
+
+WORK_DIR="$(mktemp -d)/build"
+mkdir -p "${WORK_DIR}"
+
+MANIFEST=$(cat <<EOF
+directory: "${WORK_DIR}"
+dependencies:
+  istio:
+    git: https://github.com/${GITHUB_ORG}/istio
+    branch: master
+EOF
+)
+go run main.go build \
+  --manifest <(echo "${MANIFEST}") \
+  --githubtoken "${GITHUB_TOKEN_FILE:-}" \
+  --build-base-images


### PR DESCRIPTION
its a bit confusing to have it joined with the current build.sh

`build.sh` can be cleaned up once jobs move to use this method
