### PR TITLE
Revert "[release-1.17] Allow inline docker configuration"

### DIFF
--- a/release/build.sh
+++ b/release/build.sh
@@ -23,15 +23,7 @@ cd "${ROOT}"
 
 set -eux
 
-if [[ -n "${DOCKER_CONFIG_DATA:-}" ]]; then
-  # Custom docker config as inline environment variable
-  mkdir ~/.docker
-  set +x
-  echo "${DOCKER_CONFIG_DATA}" > ~/.docker/config.json
-  set -x
-  export DOCKER_CONFIG=~/.docker
-  gcloud auth configure-docker -q
-elif [[ -n "${DOCKER_CONFIG:-}" ]]; then
+if [[ -n "${DOCKER_CONFIG:-}" ]]; then
   # If DOCKER_CONFIG is set, we are mounting a known docker config.
   # we will want to merge in gcloud options, so we can push to GCR *and* the other (docker hub) credentials.
   # However, DOCKER_CONFIG is a read only mount. So we copy it to somewhere writeable then merge in the GCR creds

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -23,15 +23,7 @@ cd "${ROOT}"
 
 set -eux
 
-if [[ -n "${DOCKER_CONFIG_DATA:-}" ]]; then
-  # Custom docker config as inline environment variable
-  mkdir ~/.docker
-  set +x
-  echo "${DOCKER_CONFIG_DATA}" > ~/.docker/config.json
-  set -x
-  export DOCKER_CONFIG=~/.docker
-  gcloud auth configure-docker -q
-elif [[ -n "${DOCKER_CONFIG:-}" ]]; then
+if [[ -n "${DOCKER_CONFIG:-}" ]]; then
   # If DOCKER_CONFIG is set, we are mounting a known docker config.
   # we will want to merge in gcloud options, so we can push to GCR *and* the other (docker hub) credentials.
   # However, DOCKER_CONFIG is a read only mount. So we copy it to somewhere writeable then merge in the GCR creds


### PR DESCRIPTION
Reverts istio/release-builder#1536
This is not safe. The `set -x` logs the config. Do not use. We will go back to using file