### PR TITLE
publish: push to target repo, not original repo

### DIFF
--- a/pkg/publish/docker.go
+++ b/pkg/publish/docker.go
@@ -164,11 +164,7 @@ func Docker(manifest model.Manifest, hub string, tags []string, cosignkey string
 				}
 			}
 		} else {
-			localImages := []string{}
-			for _, arch := range archs {
-				localImages = append(localImages, img.OriginalReference(arch))
-			}
-			digest, err := publishManifest(img.NewReference(""), localImages)
+			digest, err := publishManifest(img, archs)
 			if err != nil {
 				return err
 			}
@@ -182,33 +178,41 @@ func Docker(manifest model.Manifest, hub string, tags []string, cosignkey string
 	return nil
 }
 
-// publishManifest packages each image in `images` into a single manifest, and pushes to `manifest`.
-func publishManifest(manifest string, images []string) (string, error) {
-	log.Infof("creating manifest %v from %v", manifest, images)
+// publishManifest packages a single manifest for a multi-architecture image.
+func publishManifest(img Image, architectures []string) (string, error) {
+	log.Infof("creating manifest %v for architectures %v", img, architectures)
 	// Typically we could just use `docker manifest create manifest images...`. However, we need to actually
 	// push source images first. We want to push these without a tag, so users never use them. Docker cannot
 	// push directly by tag, so here we are...
 	craneImages := []v1.Image{}
-	for _, image := range images {
-		tagRef, err := name.ParseReference(image)
+	for _, arch := range architectures {
+		origImage := img.OriginalReference(arch)
+		origTagRef, err := name.ParseReference(origImage)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse %v: %v", image, err)
+			return "", fmt.Errorf("failed to parse %v: %v", origImage, err)
 		}
-		log.Infof("starting push of %v for manifest (without tag)", tagRef)
-		img, err := daemon.Image(tagRef)
+		newImage := img.NewReference(arch)
+		newTagRef, err := name.ParseReference(newImage)
 		if err != nil {
-			return "", fmt.Errorf("failed to load %v: %v", image, err)
+			return "", fmt.Errorf("failed to parse %v: %v", newImage, err)
+		}
+		log.Infof("starting push of %v for manifest (without tag)", origTagRef)
+		// We will load from OriginalReference, push to NewReference
+		img, err := daemon.Image(origTagRef)
+		if err != nil {
+			return "", fmt.Errorf("failed to load %v: %v", origImage, err)
 		}
 		digest, err := img.Digest()
 		if err != nil {
-			return "", fmt.Errorf("failed to get digest for %v: %v", image, err)
+			return "", fmt.Errorf("failed to get digest for %v: %v", origImage, err)
 		}
-		digestRef, err := name.NewDigest(fmt.Sprintf("%s@%s", tagRef.Context(), digest.String()))
+
+		digestRef, err := name.NewDigest(fmt.Sprintf("%s@%s", newTagRef.Context(), digest.String()))
 		if err != nil {
-			return "", fmt.Errorf("failed to build digest reference for %v: %v", image, err)
+			return "", fmt.Errorf("failed to build digest reference for %v: %v", newImage, err)
 		}
 		if err := remote.Write(digestRef, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
-			return "", fmt.Errorf("failed to push %v: %v", image, err)
+			return "", fmt.Errorf("failed to push %v: %v", newImage, err)
 		}
 		craneImages = append(craneImages, img)
 		log.Infof("pushed %v for manifest", digestRef)
@@ -253,6 +257,8 @@ func publishManifest(manifest string, images []string) (string, error) {
 			},
 		})
 	}
+	// Get target name without arch suffix
+	manifest := img.NewReference("")
 	manifestRef, err := name.ParseReference(manifest)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse %v: %v", manifestRef, err)


### PR DESCRIPTION
Example of the issue https://prow.istio.io/view/gs/istio-prow/logs/build-release_release-builder_postsubmit/1673789356160061440
```
2023-06-27T20:56:33.750026Z	info	creating manifest gcr.io/istio-prerelease-testing/install-cni:1.19.0-alpha.0-distroless from [docker.io/istio/install-cni:1.19.0-alpha.0-distroless-arm64 docker.io/istio/install-cni:1.19.0-alpha.0-distroless]
2023-06-27T20:56:33.750100Z	info	starting push of docker.io/istio/install-cni:1.19.0-alpha.0-distroless-arm64 for manifest (without tag)
Error: failed to publish to docker: failed to push docker.io/istio/install-cni:1.19.0-alpha.0-distroless-arm64: POST https://index.docker.io/v2/istio/install-cni/blobs/uploads/: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:istio/install-cni Type:repository] map[Action:push Class: Name:istio/install-cni Type:repository]]
```

note: tbh I am not sure the UNAUTHORIZED issue; will handle that later. The important part is `build-release` **should not publish to dockerhub**. It should only publish to staging.

This cleans up to properly push to the target repo.

An incoming test-infra PR will make it so the job doesn't even have access to dockerhub, so it cannot happen, even if this code is buggy.