### PR TITLE
Create amd64 named artifacts for osx and win (for consistency)

### DIFF
--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -1,7 +1,7 @@
 # Version specifies which version is being built
 # This is use for `--version`, metrics, and determining proxy capabilities.
 # Note that since this determines proxy capabilities, it is desirable to follow Istio semver
-version: 1.14.0-test
+version: 1.19.0-test
 
 # Some of the artifacts have a docker hub built in - currently this is the operator and Helm charts
 # The specified docker hub will be used there. Note - this does not effect where the images are published,

--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/release-builder/pkg/model"
 	"istio.io/release-builder/pkg/util"
 )
@@ -32,7 +34,7 @@ func Archive(manifest model.Manifest) error {
 	}
 
 	// We build archives for each arch. These contain the same thing except arch specific istioctl
-	for _, arch := range []string{"linux-amd64", "linux-armv7", "linux-arm64", "osx", "osx-arm64", "win"} {
+	for _, arch := range []string{"linux-amd64", "linux-armv7", "linux-arm64", "osx-amd64", "osx-arm64", "win-amd64"} {
 		out := path.Join(manifest.Directory, "work", "archive", arch, fmt.Sprintf("istio-%s", manifest.Version))
 		if err := os.MkdirAll(out, 0o750); err != nil {
 			return err
@@ -91,8 +93,13 @@ func Archive(manifest model.Manifest) error {
 		// Copy the istioctl binary over
 		istioctlBinary := fmt.Sprintf("istioctl-%s", arch)
 		istioctlDest := "istioctl"
-		if arch == "win" {
-			istioctlBinary += ".exe"
+		// The istioctl binaries for MacOS and Windows do not have the `-amd64` so remove from name.
+		// Windows also needs the `.exe` added.
+		if arch == "osx-amd64" {
+			istioctlBinary = istioctlBinary[:strings.LastIndexByte(istioctlBinary, '-')]
+		}
+		if arch == "win-amd64" {
+			istioctlBinary = istioctlBinary[:strings.LastIndexByte(istioctlBinary, '-')] + ".exe"
 			istioctlDest += ".exe"
 		}
 		if err := util.CopyFile(path.Join(manifest.RepoOutDir("istio"), istioctlBinary), path.Join(out, "bin", istioctlDest)); err != nil {
@@ -117,6 +124,20 @@ func Archive(manifest model.Manifest) error {
 		if err := createStandaloneIstioctl(arch, manifest, out); err != nil {
 			return err
 		}
+
+		// Handle creating additional archives of the older deprecated names.
+		// This is slower than simply copying the files, but keeps the change in one location.
+		// TODO - When we no longer need the older archives we can remove this creation.
+		if arch == "osx-amd64" || arch == "win-amd64" {
+			additionalArch := arch[:strings.IndexByte(arch, '-')]
+			if err := createArchive(additionalArch, manifest, out); err != nil {
+				return err
+			}
+
+			if err := createStandaloneIstioctl(additionalArch, manifest, out); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -125,7 +146,7 @@ func createStandaloneIstioctl(arch string, manifest model.Manifest, out string) 
 	var istioctlArchive string
 	// Create a stand alone archive for istioctl
 	// Windows should use zip, linux and osx tar
-	if arch == "win" {
+	if strings.HasPrefix(arch, "win") {
 		istioctlArchive = fmt.Sprintf("istioctl-%s-%s.zip", manifest.Version, arch)
 		if err := util.ZipFolder(path.Join(out, "bin", "istioctl.exe"), path.Join(out, "bin", istioctlArchive)); err != nil {
 			return fmt.Errorf("failed to zip istioctl: %v", err)
@@ -138,10 +159,12 @@ func createStandaloneIstioctl(arch string, manifest model.Manifest, out string) 
 			return fmt.Errorf("failed to tar istioctl: %v", err)
 		}
 	}
-	// Copy files over to the output directory
+	// Move file over to the output directory. We move the file becuase we may reuse the directory for
+	// another archive (in the case of created a non-arch named archive). Also add a log message.
 	archivePath := path.Join(out, "bin", istioctlArchive)
 	dest := path.Join(manifest.OutDir(), istioctlArchive)
-	if err := util.CopyFile(archivePath, dest); err != nil {
+	log.Infof("Moving %v -> %v", archivePath, dest)
+	if err := os.Rename(archivePath, dest); err != nil {
 		return fmt.Errorf("failed to package %v release archive: %v", arch, err)
 	}
 
@@ -156,7 +179,7 @@ func createArchive(arch string, manifest model.Manifest, out string) error {
 	var archive string
 	// Create the archive from all the above files
 	// Windows should use zip, linux and osx tar
-	if arch == "win" {
+	if strings.HasPrefix(arch, "win") {
 		archive = fmt.Sprintf("istio-%s-%s.zip", manifest.Version, arch)
 		if err := util.ZipFolder(path.Join(out, "..", fmt.Sprintf("istio-%s", manifest.Version)), path.Join(out, "..", archive)); err != nil {
 			return fmt.Errorf("failed to zip istioctl: %v", err)
@@ -171,7 +194,7 @@ func createArchive(arch string, manifest model.Manifest, out string) error {
 	}
 
 	// Copy files over to the output directory
-	archivePath := path.Join(manifest.WorkDir(), "archive", arch, archive)
+	archivePath := path.Join(out, "..", archive)
 	dest := path.Join(manifest.OutDir(), archive)
 	if err := util.CopyFile(archivePath, dest); err != nil {
 		return fmt.Errorf("failed to package %v release archive: %v", arch, err)

--- a/pkg/build/archive.go
+++ b/pkg/build/archive.go
@@ -159,7 +159,7 @@ func createStandaloneIstioctl(arch string, manifest model.Manifest, out string) 
 			return fmt.Errorf("failed to tar istioctl: %v", err)
 		}
 	}
-	// Move file over to the output directory. We move the file becuase we may reuse the directory for
+	// Move file over to the output directory. We move the file because we may reuse the directory for
 	// another archive (in the case of created a non-arch named archive). Also add a log message.
 	archivePath := path.Join(out, "bin", istioctlArchive)
 	dest := path.Join(manifest.OutDir(), istioctlArchive)


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/45677
Fixes https://github.com/istio/istio/issues/42338

This PR simply creates an additional archive with the `amd64` appended to that amd64 versions of the `win` and `osx` artifacts. The artifacts without the `amd64` are still created to prevent any issues where scripts might have been written to our old naming convention. This means we can continue with the current download scripts etc.

There should be a release note written that the non-amd64 version of the artifacts are deprecated and will be removed at a later time. This will require a rewrite of the download scripts (can be done anytime from now until the artifacts are removed).

I did not make any changes in the istio/istio makefile to create a new istioctl-win-amd64/osx-amd64 at this time. While I could do that as a prerequisite to this PR, and then make updates here to use those binaries, we might want to keep the old targets around in case anyone is using them. I  also no longer have access to a second build environment to verify those changes.

I did run a sample build and here is a list of the archive directory:
```
build-tools:/tmp/istio-release/out$ ls -la
total 736376
drwxr-x--- 8 user docker      4096 Jun 29 23:15 .
drwxr-xr-x 5 user docker      4096 Jun 29 23:00 ..
drwxr-x--- 2 user docker      4096 Jun 29 23:06 deb
drwxr-x--- 2 user docker      4096 Jun 29 23:06 docker
drwxr-xr-x 2 user docker      4096 Jun 29 23:10 grafana
drwxr-x--- 2 user docker      4096 Jun 29 23:06 helm
-rw-r--r-- 1 user docker  25052805 Jun 29 23:09 istio-1.19.0-ericvn-linux-amd64.tar.gz
-rw-r--r-- 1 user docker       104 Jun 29 23:09 istio-1.19.0-ericvn-linux-amd64.tar.gz.sha256
-rw-r--r-- 1 user docker  22624573 Jun 29 23:09 istio-1.19.0-ericvn-linux-arm64.tar.gz
-rw-r--r-- 1 user docker       104 Jun 29 23:09 istio-1.19.0-ericvn-linux-arm64.tar.gz.sha256
-rw-r--r-- 1 user docker  23497429 Jun 29 23:09 istio-1.19.0-ericvn-linux-armv7.tar.gz
-rw-r--r-- 1 user docker       104 Jun 29 23:09 istio-1.19.0-ericvn-linux-armv7.tar.gz.sha256
-rw-r--r-- 1 user docker  26605944 Jun 29 23:09 istio-1.19.0-ericvn-osx-amd64.tar.gz
-rw-r--r-- 1 user docker       102 Jun 29 23:09 istio-1.19.0-ericvn-osx-amd64.tar.gz.sha256
-rw-r--r-- 1 user docker  25773147 Jun 29 23:09 istio-1.19.0-ericvn-osx-arm64.tar.gz
-rw-r--r-- 1 user docker       102 Jun 29 23:09 istio-1.19.0-ericvn-osx-arm64.tar.gz.sha256
-rw-r--r-- 1 user docker  26605944 Jun 29 23:09 istio-1.19.0-ericvn-osx.tar.gz
-rw-r--r-- 1 user docker        96 Jun 29 23:09 istio-1.19.0-ericvn-osx.tar.gz.sha256
-rw-r--r-- 1 user docker  26182269 Jun 29 23:09 istio-1.19.0-ericvn-win-amd64.zip
-rw-r--r-- 1 user docker        99 Jun 29 23:09 istio-1.19.0-ericvn-win-amd64.zip.sha256
-rw-r--r-- 1 user docker  26182269 Jun 29 23:09 istio-1.19.0-ericvn-win.zip
-rw-r--r-- 1 user docker        93 Jun 29 23:09 istio-1.19.0-ericvn-win.zip.sha256
-rw-r--r-- 1 user docker  24796162 Jun 29 23:09 istioctl-1.19.0-ericvn-linux-amd64.tar.gz
-rw-r--r-- 1 user docker       107 Jun 29 23:09 istioctl-1.19.0-ericvn-linux-amd64.tar.gz.sha256
-rw-r--r-- 1 user docker  22365192 Jun 29 23:09 istioctl-1.19.0-ericvn-linux-arm64.tar.gz
-rw-r--r-- 1 user docker       107 Jun 29 23:09 istioctl-1.19.0-ericvn-linux-arm64.tar.gz.sha256
-rw-r--r-- 1 user docker  23239146 Jun 29 23:09 istioctl-1.19.0-ericvn-linux-armv7.tar.gz
-rw-r--r-- 1 user docker       107 Jun 29 23:09 istioctl-1.19.0-ericvn-linux-armv7.tar.gz.sha256
-rw-r--r-- 1 user docker  26345991 Jun 29 23:09 istioctl-1.19.0-ericvn-osx-amd64.tar.gz
-rw-r--r-- 1 user docker       105 Jun 29 23:09 istioctl-1.19.0-ericvn-osx-amd64.tar.gz.sha256
-rw-r--r-- 1 user docker  25513563 Jun 29 23:09 istioctl-1.19.0-ericvn-osx-arm64.tar.gz
-rw-r--r-- 1 user docker       105 Jun 29 23:09 istioctl-1.19.0-ericvn-osx-arm64.tar.gz.sha256
-rw-r--r-- 1 user docker  26345991 Jun 29 23:09 istioctl-1.19.0-ericvn-osx.tar.gz
-rw-r--r-- 1 user docker        99 Jun 29 23:09 istioctl-1.19.0-ericvn-osx.tar.gz.sha256
-rw-r--r-- 1 user docker  25716747 Jun 29 23:09 istioctl-1.19.0-ericvn-win-amd64.zip
-rw-r--r-- 1 user docker       102 Jun 29 23:09 istioctl-1.19.0-ericvn-win-amd64.zip.sha256
-rw-r--r-- 1 user docker  25716747 Jun 29 23:10 istioctl-1.19.0-ericvn-win.zip
-rw-r--r-- 1 user docker        96 Jun 29 23:10 istioctl-1.19.0-ericvn-win.zip.sha256
-rw-r--r-- 1 user docker   7018777 Jun 29 23:14 istio-release.spdx
-rw-r--r-- 1 user docker   4400238 Jun 29 23:15 istio-source.spdx
drwxr-x--- 2 user docker      4096 Jun 29 23:10 licenses
-rw-r----- 1 user docker       963 Jun 29 23:10 manifest.yaml
drwxr-x--- 2 user docker      4096 Jun 29 23:07 rpm
-rw-r--r-- 1 user docker 339872031 Jun 29 23:10 sources.tar.gz
```
Note the file sizes of the files match, although the sha256's are different. I verified the files matched the has and did a comparison of the osx and osx-amd64 extracted tars and they matched.