### PR TITLE
Remove extraneous docker buildx create

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ the latest SHAs of commits.
 1. Run `docker buildx inspect`. This will return the information about the current builder. If the current builder `Driver` is not `docker-container`, you need to create one:
 
     ```
-    docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.11.0 --name istio-builder --driver docker-container --buildkitd-flags="--debug" --use
+    docker buildx create --driver-opt network=host,image=gcr.io/istio-testing/buildkit:v0.11.0 --name container-builder --driver docker-container --buildkitd-flags="--debug" --use
     ```
 
 1. Run `crane digest gcr.io/distroless/static-debian11`. If you see an error like:

--- a/pkg/build/scanner.go
+++ b/pkg/build/scanner.go
@@ -109,10 +109,6 @@ func Scanner(manifest model.Manifest, githubToken, git, branch string) error {
 		"run", "--rm", "--privileged", "multiarch/qemu-user-static", "--reset", "-p", "yes").Run(); err != nil {
 		return fmt.Errorf("failed to run qemu-user-static container: %v", err)
 	}
-	if err := util.VerboseCommand("docker",
-		"buildx", "create", "--name", "multi-arch", "--platform", "linux/amd64,linux/arm64", "--use").Run(); err != nil {
-		return fmt.Errorf("failed to set multi-arch as current builder instance: %v", err)
-	}
 
 	targetArchitecture := os.Getenv("ARCH")
 	if targetArchitecture == "" {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/38346

The code creates an extraneous dock builder instance which is not used. There is another `container-builder` docker builder instance created and used in the istio/istio `prow/buildx-create` which is called by `tools/build-base-images.sh`

We use `istio-builder` for the name of the docker builder instance in this repo in the README, but we use `container-builder` in the istio/istio repo. We should get them to match. Will I prefer `istio-builder` that requires changes across a few files in the istio/istio repo vs one here.