### PR TITLE
Update base image code to check correct base image

### DIFF
--- a/release/build-base-images.sh
+++ b/release/build-base-images.sh
@@ -45,7 +45,7 @@ directory: "${WORK_DIR}"
 dependencies:
   istio:
     git: https://github.com/${GITHUB_ORG}/istio
-    branch: master
+    branch: release-1.19
 EOF
 )
 go run main.go build \


### PR DESCRIPTION
I noted another issue with the test failing while updating the base images.

The pipeline logic should have found this was old and updated it. However, in the prow job logs I see:
```
dependencies:
  istio:
    git: https://github.com/istio/istio
    branch: master'
```
and the test:
```

istio/base:master-2023-10-12T19-01-47 (ubuntu 22.04)
====================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

2023-10-12T23:23:27.550153Z	info	Base image scan of istio/base:master-2023-10-12T19-01-47 was successful
```
showing things are good so no new image is going to be built.

This is incorrect.

Updating the manifest should get the pipeline to look at the release-1.19 branch , find the old incorrect image and build a new one.