### PR TITLE
Remove envoy dependency in step 1

### DIFF
--- a/release/branch.sh
+++ b/release/branch.sh
@@ -60,9 +60,6 @@ ${DEPENDENCIES:-$(cat <<EOD
   enhancements:
     git: https://github.com/${REPO_ORG}/enhancements
     branch: ${BASE_BRANCH}
-  envoy:
-    git: https://github.com/${REPO_ORG}/envoy
-    branch: ${BASE_BRANCH}
   proxy:
     git: https://github.com/${REPO_ORG}/proxy
     branch: ${BASE_BRANCH}


### PR DESCRIPTION
It seems that the Envoy dependency in Istio is not being maintained. 
Actually my version of Envoy is forked from envoyproxy/envoy, and the base branch is not set to 'master' - it's 'main'. This situation is causing the error when running Automation step 1.