### PR TITLE
[release-1.20] Update build-base-images to use 1.20 branch

### DIFF
--- a/release/build-base-images.sh
+++ b/release/build-base-images.sh
@@ -45,7 +45,7 @@ directory: "${WORK_DIR}"
 dependencies:
   istio:
     git: https://github.com/${GITHUB_ORG}/istio
-    branch: master
+    branch: release-1.20
 EOF
 )
 go run main.go build \


### PR DESCRIPTION
Observed that release-1.20 build base image job created it's PR against the master branch:  https://github.com/istio/istio/pull/47585

It should be using the release-1.20 branch. This should fix that.

Once this merges, the next periodic run should update the 1.20 branch in instio/istio.