### PR TITLE
[release-1.21] Update build-base-images to use 1.21 branch

### DIFF
--- a/release/build-base-images.sh
+++ b/release/build-base-images.sh
@@ -45,7 +45,7 @@ directory: "${WORK_DIR}"
 dependencies:
   istio:
     git: https://github.com/${GITHUB_ORG}/istio
-    branch: master
+    branch: release-1.21
 EOF
 )
 go run main.go build \


### PR DESCRIPTION
Update build-base-images to use 1.21 branch

Fix the script to use the 1.21 branches to check for vulnerable images and merge if found to the 1.21 branch.