### PR TITLE
Fix versioning issues

### DIFF
--- a/example/manifest.yaml
+++ b/example/manifest.yaml
@@ -38,7 +38,7 @@ dependencies:
     auto: deps
   client-go:
     git: https://github.com/istio/client-go
-    branch: master
+    auto: modules
     goversionenabled: true
   test-infra:
     git: https://github.com/istio/test-infra
@@ -59,4 +59,5 @@ dashboards:
   istio-service-dashboard: 7636
   istio-workload-dashboard: 7630
   pilot-dashboard: 7645
+  ztunnel-dashboard: 0
 architectures: [linux/amd64, linux/arm64]

--- a/release/build-base-images.sh
+++ b/release/build-base-images.sh
@@ -38,14 +38,17 @@ GITHUB_ORG=${GITHUB_ORG:-istio}
 
 WORK_DIR="$(mktemp -d)/build"
 mkdir -p "${WORK_DIR}"
-
+BRANCH="master"
+if [[ "${VERSION}" != "master" ]]; then
+  BRANCH="release-${VERSION}"
+fi
 MANIFEST=$(cat <<EOF
 version: "${VERSION}"
 directory: "${WORK_DIR}"
 dependencies:
   istio:
     git: https://github.com/${GITHUB_ORG}/istio
-    branch: master
+    branch: "${BRANCH}"
 EOF
 )
 go run main.go build \

--- a/release/build.sh
+++ b/release/build.sh
@@ -79,7 +79,7 @@ ${DEPENDENCIES:-$(cat <<EOD
     auto: deps
   client-go:
     git: https://github.com/${GITHUB_ORG}/client-go
-    branch: master
+    auto: modules
     goversionenabled: true
   test-infra:
     git: https://github.com/${GITHUB_ORG}/test-infra
@@ -102,6 +102,7 @@ dashboards:
   istio-service-dashboard: 7636
   istio-workload-dashboard: 7630
   pilot-dashboard: 7645
+  ztunnel-dashboard: 0
 ${PROXY_OVERRIDE:-}
 EOF
 )

--- a/test/publish.sh
+++ b/test/publish.sh
@@ -97,7 +97,7 @@ ${DEPENDENCIES:-$(cat <<EOD
     auto: deps
   client-go:
     git: https://github.com/${GITHUB_ORG}/client-go
-    branch: master
+    auto: modules
     goversionenabled: true
   test-infra:
     git: https://github.com/${GITHUB_ORG}/test-infra
@@ -120,6 +120,7 @@ dashboards:
   istio-service-dashboard: 7636
   istio-workload-dashboard: 7630
   pilot-dashboard: 7645
+  ztunnel-dashboard: 0
 ${PROXY_OVERRIDE:-}
 EOF
 )


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/51425
Fixes https://github.com/istio/istio/issues/51348

Two issues:
* client-go always builds from HEAD of branch instead of where go.mod
  actually points
* Base image always uses master instead of branched
