### PR TITLE
Fix ztunnel Helm `globals` special-casing

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -269,7 +269,7 @@ func TestHelmChartVersions(r ReleaseInfo) error {
 	}
 	expected := map[string]string{
 		"cni":     "defaults.global",
-		"ztunnel": "defaults",
+		"ztunnel": "defaults.global",
 		"istiod":  "defaults.global",
 		"base":    "none",
 		"gateway": "none",


### PR DESCRIPTION
This goes with https://github.com/istio/istio/pull/51517

Fixes the `release-builder` CI failure there.