### PR TITLE
Move wrapper to samples (part 1/2)

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -58,7 +58,7 @@ var (
 		"manifests/charts/istio-control/istio-discovery",
 		"manifests/charts/istio-operator",
 		"manifests/charts/istiod-remote",
-		"manifests/charts/ambient",
+		"manifests/sample-charts/ambient",
 	}
 
 	// repoHelmCharts contains all helm charts we will release to the helm repo. This is a subset of
@@ -70,7 +70,6 @@ var (
 		"manifests/charts/ztunnel",
 		"manifests/charts/istio-control/istio-discovery",
 		"manifests/charts/istiod-remote",
-		"manifests/charts/ambient",
 	}
 )
 


### PR DESCRIPTION
This goes with https://github.com/istio/istio/pull/52013

It releases (but does not publish) the ambient wrapper chart, as per TOC decision.

Part 2 of this will be to publish the wrapper chart to a `/samples` path.

(as per usual this PR has a chicken-and-egg dependency with https://github.com/istio/istio/pull/52013 - both must be merged for their respective CIs to pass) 
