### PR TITLE
 Move wrapper to samples (part 2/2)

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -185,9 +185,6 @@ func HelmCharts(manifest model.Manifest) error {
 		if err := util.CopyDir(inDir, outDir); err != nil {
 			return err
 		}
-		if err := dropKustomize(outDir); err != nil {
-			return err
-		}
 		c := util.VerboseCommand("helm", "package", outDir)
 		c.Dir = dst
 		if err := c.Run(); err != nil {
@@ -195,22 +192,4 @@ func HelmCharts(manifest model.Manifest) error {
 		}
 	}
 	return nil
-}
-
-// Workaround for https://github.com/istio/istio/issues/44237. Eventually we will remove kustomize entirely,
-// but this is for backwards compat to remove it just from Helm charts.
-func dropKustomize(dir string) error {
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		// Check if the file name is "kustomization.yaml"
-		if info.Name() == "kustomization.yaml" {
-			// Delete the file
-			if err := os.Remove(path); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
 }

--- a/pkg/publish/cmd.go
+++ b/pkg/publish/cmd.go
@@ -58,7 +58,7 @@ var (
 			if err != nil {
 				return fmt.Errorf("failed to read manifest from release: %v", err)
 			}
-			manifest.Directory = path.Join(flags.release)
+			manifest.Directory = path.Clean(flags.release)
 			util.YamlLog("Manifest", manifest)
 
 			return Publish(manifest)

--- a/pkg/publish/helm.go
+++ b/pkg/publish/helm.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/release-builder/pkg/model"
 	"istio.io/release-builder/pkg/util"
 )
+
 // Any charts in any subdirs below the publish root that should also be published
 var chartSubtypeDir = []string{
 	"samples",

--- a/pkg/publish/helm.go
+++ b/pkg/publish/helm.go
@@ -24,12 +24,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"cloud.google.com/go/storage"
 	"sigs.k8s.io/yaml"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/release-builder/pkg/model"
 	"istio.io/release-builder/pkg/util"
 )
+// Any charts in any subdirs below the publish root that should also be published
+var chartSubtypeDir = []string{
+	"samples",
+}
 
 // Helm publishes charts to the given GCS bucket
 func Helm(manifest model.Manifest, bucket string, hub string) error {
@@ -65,21 +70,25 @@ func publishHelmIndex(manifest model.Manifest, bucket string) error {
 	}
 	bkt := client.Bucket(bucketName)
 
-	helmDir := filepath.Join(manifest.Directory, "helm")
+	helmPublishRoot := filepath.Join(manifest.Directory, "helm")
 
 	// Pull down the index, update it, and push it back up.
 	// MutateObject ensures there are no races.
-	err = MutateObject(helmDir, bkt, objectPrefix, "index.yaml", func() error {
-		dumpIndexFile(filepath.Join(helmDir, "index.yaml"), "before")
+	//
+	// Note that `helm repo index` will index charts in subdirectories as well, which
+	// is desired behavior here - we will have to push them separately however,
+	// so the index matches the bucket contents.
+	err = MutateObject(helmPublishRoot, bkt, objectPrefix, "index.yaml", func() error {
+		dumpIndexFile(filepath.Join(helmPublishRoot, "index.yaml"), "before")
 		idxCmd := util.VerboseCommand("helm", "repo", "index", ".",
 			"--url", fmt.Sprintf("https://%s.storage.googleapis.com/%s", bucketName, objectPrefix),
 			"--merge", "index.yaml")
-		idxCmd.Dir = helmDir
+		idxCmd.Dir = helmPublishRoot
 		log.Infof("Running helm repo index with dir %v", idxCmd.Dir)
 		if err := idxCmd.Run(); err != nil {
 			return fmt.Errorf("index repo: %v", err)
 		}
-		dumpIndexFile(filepath.Join(helmDir, "index.yaml"), "after")
+		dumpIndexFile(filepath.Join(helmPublishRoot, "index.yaml"), "after")
 		return nil
 	})
 	if err != nil {
@@ -94,8 +103,23 @@ func publishHelmIndex(manifest model.Manifest, bucket string) error {
 		dumpIndex(liveObject, "live")
 	}
 
-	// Now push all our charts up
-	dirInfo, err := os.ReadDir(helmDir)
+	// Now push all the packaged charts in the helm root directory up
+	if err := publishHelmBucket(ctx, helmPublishRoot, objectPrefix, bucketName, bkt); err != nil {
+		return err
+	}
+
+	// For any packaged charts in "chart subtype" subdirectories ("samples" etc), push those up
+	for _, chartType := range chartSubtypeDir {
+		if err := publishHelmBucket(ctx, filepath.Join(helmPublishRoot, chartType), path.Join(objectPrefix, chartType), bucketName, bkt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func publishHelmBucket(ctx context.Context, packagedChartOutputDir, publishPrefix, bName string, bkt *storage.BucketHandle) error {
+	dirInfo, err := os.ReadDir(packagedChartOutputDir)
 	if err != nil {
 		return err
 	}
@@ -104,10 +128,10 @@ func publishHelmIndex(manifest model.Manifest, bucket string) error {
 			log.Infof("skipping %v", f.Name())
 			continue
 		}
-		objName := path.Join(objectPrefix, f.Name())
+		objName := path.Join(publishPrefix, f.Name())
 		obj := bkt.Object(objName)
 		w := obj.NewWriter(ctx)
-		f, err := os.Open(filepath.Join(helmDir, f.Name()))
+		f, err := os.Open(filepath.Join(packagedChartOutputDir, f.Name()))
 		if err != nil {
 			return fmt.Errorf("failed to open %v: %v", f.Name(), err)
 		}
@@ -118,8 +142,9 @@ func publishHelmIndex(manifest model.Manifest, bucket string) error {
 		if err := w.Close(); err != nil {
 			return fmt.Errorf("failed to close bucket: %v", err)
 		}
-		log.Infof("Wrote %v to gs://%s/%s", f.Name(), bucketName, objName)
+		log.Infof("Wrote %v to gs://%s/%s", f.Name(), bName, objName)
 	}
+
 	return nil
 }
 
@@ -157,8 +182,25 @@ func dumpIndex(data []byte, context string) {
 }
 
 func publishHelmOCI(manifest model.Manifest, hub string) error {
-	helmDir := filepath.Join(manifest.Directory, "helm")
-	dirInfo, err := os.ReadDir(helmDir)
+	helmPublishRoot := filepath.Join(manifest.Directory, "helm")
+
+	// Now push all the packaged charts in the helm root directory up
+	if err := pushChartsInDirOCI(helmPublishRoot, hub); err != nil {
+		return err
+	}
+
+	// For any packaged charts in "chart subtype" subdirectories ("samples" etc), push those up
+	for _, chartType := range chartSubtypeDir {
+		if err := pushChartsInDirOCI(filepath.Join(helmPublishRoot, chartType), path.Join(hub, chartType)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func pushChartsInDirOCI(packagedChartOutputDir, hub string) error {
+	dirInfo, err := os.ReadDir(packagedChartOutputDir)
 	if err != nil {
 		return err
 	}
@@ -167,7 +209,7 @@ func publishHelmOCI(manifest model.Manifest, hub string) error {
 		if filepath.Ext(f.Name()) != ".tgz" {
 			continue
 		}
-		name := filepath.Join(helmDir, f.Name())
+		name := filepath.Join(packagedChartOutputDir, f.Name())
 		if err := util.VerboseCommand("helm", "push", name, "oci://"+hub).Run(); err != nil {
 			return fmt.Errorf("failed to load docker image %v: %v", f.Name(), err)
 		}


### PR DESCRIPTION
Followon from #1899 - TOC asked to publish the ambient wrapper chart under a `samples` path: https://github.com/istio/istio.io/pull/15279#issuecomment-2220493410.

This does that, which requires a bit of rework of the current publishing logic, which assumes 

- all charts are packaged to the same output dir
- the `build` and `publish` commands non-recursively publish the contents of that dir to both a bucket and OCI repos.

this mostly just nests additional "types" of charts (`samples`, whatever) in the output dir as a subdirectory, and publishes every packaged chart in the "root" output dir (existing behavior) as well as stepping into subdirs to publish those.

Note that `helm repo index` is already naturally recursive, and so (thankfully) doesn't need extra munging.


(CI will be pending https://github.com/istio/istio/pull/52013, will rekick)