### PR TITLE
Remove `istiod-remote` chart (https://github.com/istio/istio/pull/53294)

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -53,7 +53,6 @@ var (
 		"manifests/charts/istio-cni",
 		"manifests/charts/ztunnel",
 		"manifests/charts/istio-control/istio-discovery",
-		"manifests/charts/istiod-remote",
 		"manifests/sample-charts/ambient",
 	}
 
@@ -64,7 +63,6 @@ var (
 		"manifests/charts/istio-cni",
 		"manifests/charts/ztunnel",
 		"manifests/charts/istio-control/istio-discovery",
-		"manifests/charts/istiod-remote",
 	}
 
 	// repoSampleHelmCharts contains all helm charts we will release/publish as samples, rather than

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -336,7 +336,6 @@ func TestHelmVersionsIstio(r ReleaseInfo) error {
 		"manifests/charts/gateways/istio-ingress/values.yaml",
 		"manifests/charts/istio-cni/values.yaml",
 		"manifests/charts/istio-control/istio-discovery/values.yaml",
-		"manifests/charts/istiod-remote/values.yaml",
 	}
 	topLevel := []string{"manifests/charts/ztunnel/values.yaml"}
 	for _, file := range manifestValues {


### PR DESCRIPTION
Goes with https://github.com/istio/istio/pull/53294 and needs to be merged into order to unblock that PR's CI.

WG discussion: https://docs.google.com/document/d/1wsa06GGiq1LEGwhkiPP0FKIZJqdAiue-VeBonWAzAyk/edit#heading=h.smaqzr36ysjl