### PR TITLE
skip tagging images by default

### DIFF
--- a/pkg/branch/setupProw.go
+++ b/pkg/branch/setupProw.go
@@ -29,7 +29,7 @@ func SetupProw(manifest model.Manifest, release string, dryrun bool) error {
 	log.Infof("*** Updating prow config for new branches.")
 	repo := "test-infra"
 
-	cmd := util.VerboseCommand("go", "run", "./cmd/prowgen/main.go", "branch", release)
+	cmd := util.VerboseCommand("go", "run", "./cmd/prowgen/main.go", "branch", release, "--skipGarTagging")
 	cmd.Dir = path.Join(manifest.RepoDir(repo), "tools/prowgen")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to generate new prow config: %v", err)


### PR DESCRIPTION
The Istio release automation has been [stuck with a segfault for nearly two years due to a script in step 3](https://github.com/istio/istio/issues/54707) that attempts to tag images, which few release managers typically have sufficient permission to do. Passing this CLI flag should [skip the tagging step](https://github.com/istio/test-infra/blob/6b4c891ecbed60192ebab7caa240e1d505a33b30/tools/prowgen/cmd/prowgen/main.go#L117-L121) by default, and we can update the release guide to suggest finding a maintainer with sufficient permissions to perform this action manually.