### PR TITLE
Fix release-branch.sh for mac

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -14,3 +14,5 @@
 
 # this repo is on the container plan by default
 BUILD_WITH_CONTAINER ?= 1
+
+CONDITIONAL_HOST_MOUNTS = --mount type=bind,source=/tmp,destination=/tmp ${ADDITIONAL_CONDITIONAL_HOST_MOUNTS}


### PR DESCRIPTION
build-tools:/work$
build-tools:/work$
build-tools:/work$
build-tools:/work$
build-tools:/work$ REPO_ORG=istio STEP=1 ./release/branch.sh
+ DOCKER_HUB=docker.io/istio
+ REPO_ORG=istio
+ DRY_RUN=true
++ grep VERSION=
++ cut -d= -f2
2025-01-22T17:03:53.522148Z	warn	missing dependency: envoy
2025-01-22T17:03:53.522332Z	info	Running command: git clone https://github.com/istio/istio /tmp/tmp.NSSC3Cat7k/branch/sources/istio -b master --depth=1
Cloning into '/tmp/tmp.NSSC3Cat7k/branch/sources/istio'...
The authenticity of host 'github.com (140.82.121.3)' can't be established.
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Could not create directory '/home/user/.ssh' (No such file or directory).
Failed to add the host to the list of known hosts (/home/user/.ssh/known_hosts).
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Error: failed to fetch sources: failed to resolve &{Git:https://github.com/istio/istio Branch:master Sha: LocalPath: Auto: GoVersionEnabled:false}: exit status 128
exit status 1