### PR TITLE
run prowgen write after generating new config

### DIFF
--- a/pkg/branch/setupProw.go
+++ b/pkg/branch/setupProw.go
@@ -31,11 +31,18 @@ func SetupProw(manifest model.Manifest, release string, dryrun bool) error {
 	prowGenInputDir := path.Join(repo, "prow/config/jobs")
 	prowGenOutputDir := path.Join(repo, "prow/cluster/jobs")
 
-	cmd := util.VerboseCommand("go", "run", "./cmd/prowgen/main.go", "--skip-gar-tagging", "--input-dir="+prowGenInputDir,
-		"--output-dir="+prowGenOutputDir, "branch", release)
-	cmd.Dir = path.Join(repo, "tools/prowgen")
-	if err := cmd.Run(); err != nil {
+	branchCmd := util.VerboseCommand("go", "run", "./cmd/prowgen/main.go", "--skip-gar-tagging", "--input-dir="+prowGenInputDir,
+		"branch", release)
+	branchCmd.Dir = path.Join(repo, "tools/prowgen")
+	if err := branchCmd.Run(); err != nil {
 		return fmt.Errorf("failed to generate new prow config: %v", err)
+	}
+
+	writeCmd := util.VerboseCommand("go", "run", "./cmd/prowgen/main.go",
+		"--input-dir="+prowGenInputDir, "--output-dir="+prowGenOutputDir, "write")
+	writeCmd.Dir = path.Join(repo, "tools/prowgen")
+	if err := writeCmd.Run(); err != nil {
+		return fmt.Errorf("failed to write new prow config: %v", err)
 	}
 
 	privateJobsProwConfigDir := path.Join(repo, "prow/config/istio-private_jobs")


### PR DESCRIPTION
This is necessary to actually create the files in the `prow/cluster/jobs` directory that gencheck will expect. Followup to #2025

```
 Untracked files:
  (use "git add <file>..." to include in what will be committed)
	prow/cluster/jobs/istio-private/istio.io/istio-private.istio.io.release-1.25.gen.yaml
	prow/cluster/jobs/istio-private/istio/istio-private.istio.release-1.25.gen.yaml
	prow/cluster/jobs/istio-private/proxy/istio-private.proxy.release-1.25.gen.yaml
	prow/cluster/jobs/istio-private/release-builder/istio-private.release-builder.release-1.25.gen.yaml
	prow/cluster/jobs/istio/api/istio.api.release-1.25.gen.yaml
	prow/cluster/jobs/istio/client-go/istio.client-go.release-1.25.gen.yaml
	prow/cluster/jobs/istio/common-files/istio.common-files.release-1.25.gen.yaml
	prow/cluster/jobs/istio/enhancements/istio.enhancements.release-1.25.gen.yaml
	prow/cluster/jobs/istio/istio.io/istio.istio.io.release-1.25.gen.yaml
	prow/cluster/jobs/istio/istio/istio.istio.release-1.25.gen.yaml
	prow/cluster/jobs/istio/proxy/istio.proxy.release-1.25.gen.yaml
	prow/cluster/jobs/istio/release-builder/istio.release-builder.release-1.25.gen.yaml
	prow/cluster/jobs/istio/tools/istio.tools.release-1.25.gen.yaml
	prow/cluster/jobs/istio/ztunnel/istio.ztunnel.release-1.25.gen.yaml 
```

/cc @kfaseela @dhawton 