### PR TITLE
fix build validation after registry.istio.io migration

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -42,7 +42,7 @@ var (
 	}
 
 	// Currently tags are set as `gcr.io/istio-testing` or `gcr.io/istio-release`
-	hubs = []string{"gcr.io/istio-testing", "gcr.io/istio-release"}
+	hubs = []string{"gcr.io/istio-testing", "gcr.io/istio-release", "registry.istio.io/testing", "registry.istio.io/release"}
 
 	// helmCharts contains all helm charts we will package and publish
 	helmCharts = []string{

--- a/release/build.sh
+++ b/release/build.sh
@@ -47,7 +47,7 @@ if [[ -n ${ISTIO_ENVOY_BASE_URL:-} ]]; then
 fi
 
 # We shouldn't push here right now, this is just which version to embed in the Helm charts
-DOCKER_HUB=${DOCKER_HUB:-registry.istio.io/testing}
+DOCKER_HUB=${DOCKER_HUB:-registry.istio.io/release}
 
 # When set, we skip the actual build, scan base images, and create and push new ones if needed.
 BUILD_BASE_IMAGES=${BUILD_BASE_IMAGES:=false}
@@ -110,11 +110,3 @@ EOF
 go run main.go build --manifest <(echo "${MANIFEST}")
 
 go run main.go validate --release "${WORK_DIR}/out"
-
-go run main.go publish --release "${WORK_DIR}/out" \
-  --cosignkey "${COSIGN_KEY:-}" \
-  --gcsbucket "${GCS_BUCKET}" \
-  --helmbucket "${HELM_BUCKET}" \
-  --helmhub "${PRERELEASE_DOCKER_HUB}/charts" \
-  --dockerhub "${PRERELEASE_DOCKER_HUB}" \
-  --dockertags "${VERSION}"

--- a/release/build.sh
+++ b/release/build.sh
@@ -47,7 +47,7 @@ if [[ -n ${ISTIO_ENVOY_BASE_URL:-} ]]; then
 fi
 
 # We shouldn't push here right now, this is just which version to embed in the Helm charts
-DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
+DOCKER_HUB=${DOCKER_HUB:-registry.istio.io/testing}
 
 # When set, we skip the actual build, scan base images, and create and push new ones if needed.
 BUILD_BASE_IMAGES=${BUILD_BASE_IMAGES:=false}


### PR DESCRIPTION
istio/istio#59364 changed the default hub to registry.istio.io/testing but release-builder validation still expects docker.io/istio, causing the 1.30 alpha build to fail. Ref https://github.com/istio/istio/issues/59425