### PR TITLE
Revert default registry in helm charts to docker

### DIFF
--- a/pkg/build/helm.go
+++ b/pkg/build/helm.go
@@ -41,8 +41,8 @@ var (
 		regexp.MustCompile(`"tag": "latest"`),
 	}
 
-	// Currently tags are set as `gcr.io/istio-testing`, `gcr.io/istio-release`, `registry.istio.io/testing`, or `registry.istio.io/release`
-	hubs = []string{"gcr.io/istio-testing", "gcr.io/istio-release", "registry.istio.io/testing", "registry.istio.io/release"}
+	// Currently tags are set as `gcr.io/istio-testing`, `gcr.io/istio-release`, `registry.istio.io/testing`
+	hubs = []string{"gcr.io/istio-testing", "gcr.io/istio-release", "registry.istio.io/testing"}
 
 	// helmCharts contains all helm charts we will package and publish
 	helmCharts = []string{

--- a/release/build.sh
+++ b/release/build.sh
@@ -51,7 +51,7 @@ if [[ -n ${ISTIO_ENVOY_BASE_URL:-} ]]; then
 fi
 
 # this is just which version to embed in the Helm charts
-DOCKER_HUB=${DOCKER_HUB:-registry.istio.io/release}
+DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
 
 # When set, we skip the actual build, scan base images, and create and push new ones if needed.
 BUILD_BASE_IMAGES=${BUILD_BASE_IMAGES:=false}


### PR DESCRIPTION
I think there is consensus that the cloudflare registry "redirector" is not working out and we should just push to docker. In the future, we should also push to other registries. Will make a blog post about this.