### PR TITLE
Remove pushes to gcp-related things 

### DIFF
--- a/release/build-base-images.sh
+++ b/release/build-base-images.sh
@@ -23,17 +23,6 @@ cd "${ROOT}"
 
 set -eux
 
-if [[ -n "${DOCKER_CONFIG:-}" ]]; then
-  # If DOCKER_CONFIG is set, we are mounting a known docker config.
-  # we will want to merge in gcloud options, so we can push to GCR *and* the other (docker hub) credentials.
-  # However, DOCKER_CONFIG is a read only mount. So we copy it to somewhere writeable then merge in the GCR creds
-  mkdir ~/.docker
-  cp "${DOCKER_CONFIG}/config.json" ~/.docker/
-  export DOCKER_CONFIG=~/.docker
-  gcloud auth configure-docker -q
-fi
-# No else needed - the prow entrypoint already runs configure-docker for standard cases
-
 GITHUB_ORG=${GITHUB_ORG:-istio}
 
 WORK_DIR="$(mktemp -d)/build"

--- a/release/build.sh
+++ b/release/build.sh
@@ -24,22 +24,9 @@ cd "${ROOT}"
 set -eu
 set +x
 
-if [[ -n "${DOCKER_CONFIG:-}" ]]; then
-  # If DOCKER_CONFIG is set, we are mounting a known docker config.
-  # we will want to merge in gcloud options, so we can push to GCR *and* the other (docker hub) credentials.
-  # However, DOCKER_CONFIG is a read only mount. So we copy it to somewhere writeable then merge in the GCR creds
-  mkdir ~/.docker
-  cp "${DOCKER_CONFIG}/config.json" ~/.docker/
-  export DOCKER_CONFIG=~/.docker
-  gcloud auth configure-docker -q
-fi
-# No else needed - the prow entrypoint already runs configure-docker for standard cases
-
 # Where to push images
-PRERELEASE_DOCKER_HUB=${PRERELEASE_DOCKER_HUB:-gcr.io/istio-prerelease-testing}
-GCS_BUCKET=${GCS_BUCKET:-istio-prerelease/prerelease}
+PRERELEASE_DOCKER_HUB=${PRERELEASE_DOCKER_HUB:-ghcr.io/istio/prerelease-testing}
 R2_BUCKET=${R2_BUCKET:-istio-prerelease/prerelease}
-HELM_BUCKET=${HELM_BUCKET:-istio-prerelease/charts}
 R2_HELM_BUCKET=${R2_HELM_BUCKET:-istio-prerelease/charts}
 COSIGN_KEY=${COSIGN_KEY:-}
 GITHUB_ORG=${GITHUB_ORG:-istio}
@@ -127,9 +114,7 @@ export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION AWS_SESSION_TOKEN
 # We build to both r2 and gcs, but the publish action uses r2 as the source.
 go run main.go publish --release "${WORK_DIR}/out" \
   --cosignkey "${COSIGN_KEY:-}" \
-  --gcsbucket "${GCS_BUCKET}" \
   --s3bucket "${R2_BUCKET}" \
-  --helmbucket "${HELM_BUCKET}" \
   --s3helmbucket "${R2_HELM_BUCKET}" \
   --helmhub "${PRERELEASE_DOCKER_HUB}/charts" \
   --dockerhub "${PRERELEASE_DOCKER_HUB}" \

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -24,29 +24,14 @@ cd "${ROOT}"
 set -eu
 set +x
 
-if [[ -n "${DOCKER_CONFIG:-}" ]]; then
-  # If DOCKER_CONFIG is set, we are mounting a known docker config.
-  # we will want to merge in gcloud options, so we can push to GCR *and* the other (docker hub) credentials.
-  # However, DOCKER_CONFIG is a read only mount. So we copy it to somewhere writeable then merge in the GCR creds
-  mkdir ~/.docker
-  cp "${DOCKER_CONFIG}/config.json" ~/.docker/
-  export DOCKER_CONFIG=~/.docker
-  gcloud auth configure-docker -q
-fi
-# No else needed - the prow entrypoint already runs configure-docker for standard cases
-
-
 VERSION="$(cat "${WD}/trigger-publish")"
 
 SOURCE_R2_BUCKET=${SOURCE_R2_BUCKET:-istio-prerelease/prerelease}
-GCS_BUCKET=${GCS_BUCKET:-istio-release/releases}
 R2_BUCKET=${R2_BUCKET:-istio-release/releases}
-HELM_BUCKET=${HELM_BUCKET:-istio-release/charts}
 R2_HELM_BUCKET=${R2_HELM_BUCKET:-istio-release/charts}
-HELM_HUB_RELEASE=${HELM_HUB_RELEASE:-gcr.io/istio-release/charts}
 # We actually push to these hubs. This doesn't affect the default hub in Helm charts
 DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
-DOCKER_HUB_MIRROR=${DOCKER_HUB_MIRROR:-gcr.io/istio-release}
+HELM_HUB_RELEASE=${HELM_HUB_RELEASE:-${DOCKER_HUB}/charts}
 GITHUB_ORG=${GITHUB_ORG:-istio}
 GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE:-}
 GRAFANA_TOKEN_FILE=${GRAFANA_TOKEN_FILE:-}
@@ -69,20 +54,10 @@ AWS_ACCESS_KEY_ID="$(echo "${CF_CREDENTIALS}" | jq -r '.access_key' | tr -d '\n'
     AWS_SESSION_TOKEN="$(echo "${CF_CREDENTIALS}" | jq -r '.session_token' | tr -d '\n')" \
     go run main.go publish --release "${WORK_DIR}" \
     --cosignkey "${COSIGN_KEY:-}" \
-    --gcsbucket "${GCS_BUCKET}" \
     --s3bucket "${R2_BUCKET}" \
-    --helmbucket "${HELM_BUCKET}" \
     --s3helmbucket "${R2_HELM_BUCKET}" \
+    --helmhub "${HELM_HUB_RELEASE}" \
     --dockerhub "${DOCKER_HUB}" --dockertags "${VERSION}" \
     --github "${GITHUB_ORG}" --githubtoken "${GITHUB_TOKEN_FILE}" \
     --grafanatoken "${GRAFANA_TOKEN_FILE}" \
     --s3-base-endpoint "${ENDPOINT}"
-
-# Also push images to a GCR repo, in case of dockerhub rate limiting issues for
-# large clusters (see https://docs.docker.com/docker-hub/download-rate-limit/).
-# Docker hub doesn't support Helm registries, so we also push these only to GCR.
-go run main.go publish --release "${WORK_DIR}" \
-    --cosignkey "${COSIGN_KEY:-}" \
-    --helmhub "${HELM_HUB_RELEASE}" \
-    --dockerhub "${DOCKER_HUB_MIRROR}" \
-    --dockertags "${VERSION}"


### PR DESCRIPTION
So we don't push to Google Artifact Registry and Google Cloud Storage, and we push to prerelease.