### PR TITLE
push oci helm charts to ghcr

### DIFF
--- a/release/publish.sh
+++ b/release/publish.sh
@@ -31,7 +31,7 @@ R2_BUCKET=${R2_BUCKET:-istio-release/releases}
 R2_HELM_BUCKET=${R2_HELM_BUCKET:-istio-release/charts}
 # We actually push to these hubs. This doesn't affect the default hub in Helm charts
 DOCKER_HUB=${DOCKER_HUB:-docker.io/istio}
-HELM_HUB_RELEASE=${HELM_HUB_RELEASE:-${DOCKER_HUB}/charts}
+HELM_HUB_RELEASE=${HELM_HUB_RELEASE:-ghcr.io/istio/release/charts}
 GITHUB_ORG=${GITHUB_ORG:-istio}
 GITHUB_TOKEN_FILE=${GITHUB_TOKEN_FILE:-}
 GRAFANA_TOKEN_FILE=${GRAFANA_TOKEN_FILE:-}


### PR DESCRIPTION
Unfortunately, docker does not support paths liek docker.io/istio/charts/istiod. It only supports two path segments. We should push to GHCR instead.